### PR TITLE
fix(Transactions.vue): display in-chat transfers also

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "idb": "^2.1.3",
     "instascan": "git+https://github.com/schmich/instascan.git#master",
     "js-base64": "^2.4.9",
+    "lodash": "^4.17.11",
     "marked": "^0.3.6",
     "material-design-icons-iconfont": "^3.0.3",
     "pbkdf2": "^3.0.16",

--- a/src/lib/adamant-api.js
+++ b/src/lib/adamant-api.js
@@ -373,7 +373,7 @@ export function storeCryptoAddress (crypto, address) {
 export function getTransactions (options = { }) {
   const query = {
     inId: myAddress,
-    'and:type': options.type || Transactions.SEND,
+    'and:minAmount': 1,
     orderBy: 'timestamp:desc'
   }
 
@@ -383,6 +383,10 @@ export function getTransactions (options = { }) {
 
   if (options.from) {
     query['and:fromHeight'] = options.from
+  }
+
+  if (options.type) {
+    query['and:type'] = options.type
   }
 
   return client.get('/api/transactions', query)

--- a/src/lib/lsStore.js
+++ b/src/lib/lsStore.js
@@ -1,4 +1,5 @@
 import merge from 'deepmerge'
+import cloneDeep from 'lodash/cloneDeep'
 import {
   decryptData,
   encryptData,
@@ -65,6 +66,7 @@ export default function storeData () {
     if (value !== 'undefined') {
       if (value) {
         value = JSON.parse(value)
+        delete value.areChatsLoading // for users who already have this property
       }
     }
     if (typeof value === 'object' && value !== null) {
@@ -181,7 +183,9 @@ export default function storeData () {
         let storeNow = false
         if (mutation.type === 'change_storage_method') {
           if (!mutation.payload) {
-            useStorage = sessionStorage.setItem('adm-persist', JSON.stringify(state))
+            const clonedState = cloneDeep(state)
+            delete clonedState.areChatsLoading
+            useStorage = sessionStorage.setItem('adm-persist', JSON.stringify(clonedState))
           }
           try {
             mainStorage.setItem('storeInLocalStorage', mutation.payload)
@@ -228,7 +232,9 @@ export default function storeData () {
         }
         if (storeNow) {
           try {
-            useStorage.setItem('adm-persist', JSON.stringify(state))
+            const clonedState = cloneDeep(state)
+            delete clonedState.areChatsLoading
+            useStorage.setItem('adm-persist', JSON.stringify(clonedState))
           } catch (e) {
           }
         } else {

--- a/src/views/Transfer.vue
+++ b/src/views/Transfer.vue
@@ -39,7 +39,7 @@
               <md-input type="number" readonly v-model="finalAmount"></md-input>
           </md-input-container>
 
-          <md-input-container v-if="this.fixedAddress && this.crypto !== 'ADM'">
+          <md-input-container v-if="this.fixedAddress">
             <label>{{ $t('transfer.comments_label') }}</label>
             <md-input v-model="comments" maxlength='100'></md-input>
           </md-input-container>


### PR DESCRIPTION
fix(lcStore): do not store `areChatsLoading` inside SS, in order not to
block `actions.loadChats` execution

Transfer.vue: display `comments` field when sending ADM from chat
adamant-api: fetch transactions + in-chat transactions
package.json: add lodash