### PR TITLE
fix(chat): fix confirmation icon

### DIFF
--- a/src/components/chat/AdmMessage.vue
+++ b/src/components/chat/AdmMessage.vue
@@ -7,6 +7,7 @@
     :brief="brief"
     :readOnly="readOnly"
     :message="message"
+    :show-confirm-icon="message.amount > 0"
   >
     <p v-if="message.amount">
       {{ $t("chats." + (message.direction === "from" ? "sent_label" : "received_label")) }}

--- a/src/components/chat/ChatEntryTemplate.vue
+++ b/src/components/chat/ChatEntryTemplate.vue
@@ -8,7 +8,7 @@
       }"
       v-if="!brief"
     >
-      <div v-if="amount > 0 || direction === 'from'" class="message-tick" :data-confirmation="confirm">
+      <div class="message-tick" :data-confirmation="confirm">
         <md-icon>{{ messageTick[confirm] || 'done' }}</md-icon>
       </div>
       <div v-if="readOnly" class="adamant-avatar"></div>
@@ -28,7 +28,7 @@
       </div>
     </md-layout>
     <div v-if="brief" class="brief-message-wrapper">
-      <div class="brief-message-tick" :direction="direction" :data-confirmation="confirm">
+      <div v-if="showConfirmIcon" class="brief-message-tick" :direction="direction" :data-confirmation="confirm">
         <md-icon>{{ messageTick[confirm] }}</md-icon>
       </div>
       <div class="brief-message-text" :direction="direction">
@@ -57,7 +57,7 @@ export default {
     }
   },
   name: 'chat-entry-template',
-  props: ['confirm', 'direction', 'timestamp', 'brief', 'readOnly', 'message', 'amount'],
+  props: ['confirm', 'direction', 'timestamp', 'brief', 'readOnly', 'message', 'amount', 'showConfirmIcon'],
   methods: {
     retryMessage () {
       this.$store.dispatch('retry_message', this.message.id)

--- a/src/components/chat/CryptoTransfer.vue
+++ b/src/components/chat/CryptoTransfer.vue
@@ -4,12 +4,12 @@
     :direction="message.direction"
     :timestamp="message.timestamp"
     :brief="brief"
+    :show-confirm-icon="true"
   >
     <p>{{ $t("chats." + (message.direction === "from" ? "sent_label" : "received_label")) }}</p>
     <p class='transaction-amount' v-on:click="goToTransaction()">
       <span v-text="message.message.amount"></span> {{ crypto }}
     </p>
-    <div v-if="message.direction === 'to'" class="message-tick received-message-tick" :data-confirmation="confirm"></div>
     <p><em v-text="message.message.comments"></em></p>
     <template slot="brief-view">
       <span>{{ $t("chats." + (message.direction === "from" ? "sent_label" : "received_label")) }} </span>


### PR DESCRIPTION
- CryptoTransfer.vue: remove unused div `message-tick`
- Chat: display icon confirmation for DOGE & ETH
- Chats: display icon confirmation only for transactions