### PR TITLE
Remove not needed numbers

### DIFF
--- a/src/filters/numberFormat.js
+++ b/src/filters/numberFormat.js
@@ -1,0 +1,12 @@
+import BigNumber from '@/lib/bignumber'
+
+/**
+ * Format currency amount to a fancy string with symbol
+ * @param {number} amount - Amount to format
+ * @param {number} precision - number of decimal digits
+ * @returns {string}
+ */
+export default (amount, precision = null) => {
+  const formatted = BigNumber(amount).toFixed(precision)
+  return `${formatted}`
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ import router from './router'
 import store from './store'
 import i18n from './i18n'
 import currencyFilter from './filters/currency'
+import numberFormatFilter from './filters/numberFormat'
 import VueFormatters from './lib/formatters'
 import packageJSON from '../package.json'
 import './plugins/vuetify'
@@ -18,6 +19,7 @@ document.title = i18n.t('app_title')
 
 Vue.config.productionTip = false
 Vue.filter('currency', currencyFilter)
+Vue.filter('numberFormat', numberFormatFilter)
 
 window.ep = new Vue({
   version: packageJSON.version,

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -16,7 +16,7 @@
                 <icon :width="36" :height="36" fill="#BDBDBD" slot="icon" class="mb-2">
                   <component :is="wallet.icon"/>
                 </icon>
-                <div>{{ wallet.balance }}</div>
+                <div>{{ wallet.balance | numberFormat(4)  }}</div>
                 <div>{{ wallet.cryptoCurrency }}</div>
               </div>
             </v-tab>


### PR DESCRIPTION
When displaying balances on home tab, we do not need more than 4 significant digits shown.