### PR TITLE
ETHLike and BTCLike: timeout, interval, attempts

### DIFF
--- a/src/mixins/transaction.js
+++ b/src/mixins/transaction.js
@@ -94,6 +94,9 @@ export default {
       const recipientCryptoAddress = this.$store.getters['partners/cryptoAddress'](recipientId, type)
       const senderCryptoAddress = this.$store.getters['partners/cryptoAddress'](senderId, type)
 
+      // do not update status until cryptoAddresses and transaction are received
+      if (!recipientCryptoAddress || !senderCryptoAddress || !transaction) return TS.PENDING
+
       if (status === 'SUCCESS') {
         if (this.verifyTransactionDetails(transaction, admSpecialMessage, {
           recipientCryptoAddress,

--- a/src/store/modules/eth-base/eth-base-actions.js
+++ b/src/store/modules/eth-base/eth-base-actions.js
@@ -137,17 +137,17 @@ export default function createActions (config) {
       const transaction = context.state.transactions[payload.hash]
       if (!transaction) return
 
-      const supplier = () => api.eth.getBlock.request(payload.blockNumber, (err, tx) => {
-        if (!err && tx) {
+      const supplier = () => api.eth.getBlock.request(payload.blockNumber, (err, block) => {
+        if (!err && block) {
           context.commit('transactions', [{
-            hash: payload.hash,
-            timestamp: tx.timestamp * 1000
+            hash: transaction.hash,
+            timestamp: block.timestamp * 1000
           }])
         }
-        if (!tx && payload.attempt === MAX_ATTEMPTS) {
+        if (!block && payload.attempt === MAX_ATTEMPTS) {
           // Give up, if transaction could not be found after so many attempts
-          context.commit('transactions', [{ hash: tx.hash, status: 'ERROR' }])
-        } else if (err || !tx || !tx.status) {
+          context.commit('transactions', [{ hash: transaction.hash, status: 'ERROR' }])
+        } else if (err || !block) {
           // In case of an error or a pending transaction fetch its receipt once again later
           // Increment attempt counter, if no transaction was found so far
           const newPayload = { ...payload, attempt: 1 + (payload.attempt || 0) }

--- a/src/store/modules/eth-base/eth-base-actions.js
+++ b/src/store/modules/eth-base/eth-base-actions.js
@@ -7,7 +7,9 @@ import * as utils from '../../../lib/eth-utils'
 import { getTransactions } from '../../../lib/eth-index'
 
 /** Max number of attempts to retrieve the transaction details */
-const MAX_ATTEMPTS = 150
+const MAX_ATTEMPTS = 5
+const NEW_TRANSACTION_TIMEOUT = 60
+const OLD_TRANSACTION_TIMEOUT = 5
 
 const CHUNK_SIZE = 25
 
@@ -201,7 +203,9 @@ export default function createActions (config) {
           // In case of an error or a pending transaction fetch its details once again later
           // Increment attempt counter, if no transaction was found so far
           const newPayload = tx ? payload : { ...payload, attempt: 1 + (payload.attempt || 0) }
-          context.dispatch('getTransaction', newPayload)
+
+          const timeout = payload.isNew ? NEW_TRANSACTION_TIMEOUT : OLD_TRANSACTION_TIMEOUT
+          setTimeout(() => context.dispatch('getTransaction', newPayload), timeout * 1000)
         }
       })
 


### PR DESCRIPTION
- 5 attempts
- 5 sec interval (old transactions)
- 60 sec interval (new transactions)