### PR TITLE
Fix electron white screen after production build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@ yarn-error.log*
 *.sln
 *.sw*
 
-#Electron-builder output
+# Electron-builder output
 /dist-electron
+# Electron app will be placed here after packaging
+/release-electron
 
 # Yarn
 .yarn

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ npm run electron:dev
 npm run electron:build
 ```
 
+### Build electron for macOS, Windows and Linux
+
+```
+npm run electron:build:mwl
+```
+
 ### Preview electron production build
 
 ```

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,11 +1,14 @@
 productName: ADAMANT Messenger
 appId: im.adamant.msg
 
-files: 
-  - '!**/node_modules/*/{CHANGELOG.md,README.md,README,readme.md,readme,test,__tests__,tests,powered-test,example,examples,*.d.ts}'
-  - '!**/._*'
-  - '!**/node_modules/.bin'
-  - '!**/{report.html,robots.txt,.DS_Store,.git,.hg,.svn,CVS,RCS,SCCS,__pycache__,thumbs.db,.gitignore,.gitattributes,.editorconfig,.flowconfig,.yarn-metadata.json,.idea,appveyor.yml,.travis.yml,circle.yml,npm-debug.log,.nyc_output,yarn.lock,.yarn-integrity}'
+files:
+  - "!**/node_modules/**"
+  - "dist-electron"
+  - "package.json"
+
+directories:
+  output: './release-electron'
+  buildResources: './build'
 
 protocols:
   - name: ADAMANT Messenger

--- a/electron-vite.config.ts
+++ b/electron-vite.config.ts
@@ -6,9 +6,12 @@ import viteConfig from './vite.config'
 export default mergeConfig(
   viteConfig,
   defineConfig({
+    build: {
+      outDir: './dist-electron'
+    },
     plugins: [
       electron({
-        entry: 'electron/main.js'
+        entry: 'src/electron/main.js'
       })
     ]
   })

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint --ext .js,.vue --ignore-path .gitignore --fix src",
     "prettify": "prettier --write src/",
     "electron:build": "vue-tsc && vite build --config electron-vite.config.ts && electron-builder",
+    "electron:build:mwl": "vue-tsc && vite build --config electron-vite.config.ts && electron-builder -mwl",
     "electron:dev": "vite dev --config electron-vite.config.ts",
     "electron:serve": "vite preview --config electron-vite.config.ts",
     "https": "vite preview --https",


### PR DESCRIPTION
fix(electron): fix white screen after production build

* feat(src/electron/main.js): use custom `app://` scheme instead of `file://`

* fix(electron-builder.yml): exclude unused files before packaging to reduce the app size

* chore(electron-vite.config.ts): set `build.outDir` to `dist-electron` when building Vue app for Electron

* chore(electron-builder.yml): packaged apps will be placed in `./release-electron`

