### PR TITLE
fix(VitePWA): main.js is not cached by SW due to `maximumFileSizeToCacheInBytes`

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,6 +20,9 @@ export default defineConfig({
       filename: 'service-worker.js',
       devOptions: {
         enabled: false
+      },
+      workbox: {
+        maximumFileSizeToCacheInBytes: 5000000 // 5 MiB
       }
     })
   ],


### PR DESCRIPTION
https://trello.com/c/KljLS5TJ/356-the-app-is-trying-to-load-the-old-js-file-due-to-the-sw-cache