### PR TITLE
center loading element

### DIFF
--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -3,7 +3,7 @@
     v-if="isLoadingSeparator"
   >
     <div
-      style="align-items: center"
+      class="d-flex justify-center"
     >
       <v-icon
         ref="loadingDots"


### PR DESCRIPTION
https://trello.com/c/Lw45qdDZ/355-bug-make-loading-chat-animation-centered

Not sure this is the same as on https://msg.adamant.im/chats because I don't have enough chats to check but I basically just centered the element so there should be no room for error