### PR TITLE
fix(ChatForm): don't overflow the chat when typing a multiline message

### DIFF
--- a/src/assets/styles/components/_chat.scss
+++ b/src/assets/styles/components/_chat.scss
@@ -1,8 +1,6 @@
 @import 'vuetify/settings';
 @import '../settings/_colors.scss';
 
-$chat-form-height: 52px;
-
 $chat-sender: (
   'font-size': 15px,
   'line-height': 1.2
@@ -21,7 +19,6 @@ $chat-avatar-size: 40px;
   text-decoration: none;
   height: 100%;
   position: relative;
-  padding-bottom: $chat-form-height;
 
   &__content {
     height: inherit;
@@ -256,9 +253,7 @@ $chat-avatar-size: 40px;
 
   &__form {
     padding: 8px;
-    position: absolute;
-    left: 0;
-    bottom: 0;
+    position: static;
     width: 100%;
 
     /**

--- a/src/assets/styles/components/_chat.scss
+++ b/src/assets/styles/components/_chat.scss
@@ -253,7 +253,7 @@ $chat-avatar-size: 40px;
 
   &__form {
     padding: 8px;
-    position: static;
+    position: relative;
     width: 100%;
 
     /**

--- a/src/components/AChat/AChat.vue
+++ b/src/components/AChat/AChat.vue
@@ -92,10 +92,21 @@ export default {
   mounted () {
     this.attachScrollListener()
 
+    this.currentClientHeight = this.$refs.messages.clientHeight
     const resizeHandler = () => {
       const clientHeightDelta = this.currentClientHeight - this.$refs.messages.clientHeight
 
-      this.$refs.messages.scrollTop += clientHeightDelta
+      const nonVisibleClientHeight =
+        this.$refs.messages.scrollHeight -
+        this.$refs.messages.clientHeight -
+        this.$refs.messages.scrollTop
+      const scrolledToBottom = nonVisibleClientHeight === 0
+
+      if (scrolledToBottom) {
+        // Browser updates Element.scrollTop by itself
+      } else {
+        this.$refs.messages.scrollTop += clientHeightDelta
+      }
 
       this.currentClientHeight = this.$refs.messages.clientHeight
     }

--- a/src/components/AChat/AChat.vue
+++ b/src/components/AChat/AChat.vue
@@ -86,13 +86,26 @@ export default {
   emits: ['scroll', 'scroll:bottom', 'scroll:top'],
   data: () => ({
     currentScrollHeight: 0,
-    currentScrollTop: 0
+    currentScrollTop: 0,
+    currentClientHeight: 0
   }),
   mounted () {
     this.attachScrollListener()
+
+    const resizeHandler = () => {
+      const clientHeightDelta = this.currentClientHeight - this.$refs.messages.clientHeight
+
+      this.$refs.messages.scrollTop += clientHeightDelta
+
+      this.currentClientHeight = this.$refs.messages.clientHeight
+    }
+
+    this.resizeObserver = new ResizeObserver(resizeHandler)
+    this.resizeObserver.observe(this.$refs.messages)
   },
   beforeUnmount () {
     this.destroyScrollListener()
+    this.resizeObserver?.unobserve(this.$refs.messages)
   },
   methods: {
     attachScrollListener () {


### PR DESCRIPTION
https://trello.com/c/7jZEG9rt/228-bug-multiple-strings-hide-last-messages