### PR TITLE
fix(Chat): Android navigation menu overflows chat form

### DIFF
--- a/src/assets/styles/components/_chat.scss
+++ b/src/assets/styles/components/_chat.scss
@@ -19,7 +19,10 @@ $scroll-bar-width: 4px;
 .a-chat {
   display: block;
   text-decoration: none;
-  height: 100%;
+  height: 100%; // <-- Fallback for Chrome < v108
+  // Chrome supports `dvh, lvh...` units starting with v108.
+  // See https://caniuse.com/viewport-unit-variants
+  height: 100dvh;
   position: relative;
 
   &__content {


### PR DESCRIPTION
https://trello.com/c/PccXlMC7/390-bug-message-entry-field-missing