### PR TITLE
fix(chat): added ellipsis for long chat names

### DIFF
--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -282,9 +282,6 @@ export default {
   }
 
   &__title {
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
     line-height: 24px;
     margin-bottom: 0;
   }

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -27,13 +27,18 @@
     </template>
 
     <div>
-      <v-list-item-title
-        :class="{
-          'a-text-regular-enlarged-bold': true,
-          [`${className}__title`]: true
-        }"
-        v-text="isAdamantChat(contactId) ? $t(contactName) : contactName"
-      />
+      <div :class="`${className}__heading`">
+        <v-list-item-title
+          :class="{
+            'a-text-regular-enlarged-bold': true,
+            [`${className}__title`]: true
+          }"
+          v-text="isAdamantChat(contactId) ? $t(contactName) : contactName"
+        />
+        <div v-if="!isMessageReadonly" :class="`${className}__date`">
+          {{ formatDate(createdAt) }}
+        </div>
+      </div>
 
       <!-- New chat (no messages yet) -->
       <template v-if="isNewChat">
@@ -69,10 +74,6 @@
           {{ lastMessageTextNoFormats }}
         </v-list-item-subtitle>
       </template>
-    </div>
-
-    <div v-if="!isMessageReadonly" :class="`${className}__date`">
-      {{ formatDate(createdAt) }}
     </div>
   </v-list-item>
 </template>
@@ -262,6 +263,7 @@ export default {
 /**
  * 1. Message/Transaction content.
  */
+
 .chat-brief {
   position: relative;
 
@@ -275,11 +277,15 @@ export default {
     margin-right: 16px;
   }
 
+  &__heading {
+    display: flex;
+    justify-content: space-between;
+  }
+
   &__title {
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
-    margin-right: 80px;
     line-height: 24px;
     margin-bottom: 0;
   }
@@ -294,7 +300,8 @@ export default {
 
   &__date {
     @include a-text-explanation-small();
-    position: absolute;
+    margin-left: 16px;
+    white-space: nowrap;
     top: 16px;
     right: 16px;
   }

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -276,6 +276,10 @@ export default {
   }
 
   &__title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    margin-right: 80px;
     line-height: 24px;
     margin-bottom: 0;
   }

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -263,7 +263,6 @@ export default {
 /**
  * 1. Message/Transaction content.
  */
-
 .chat-brief {
   position: relative;
 

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -279,6 +279,7 @@ export default {
   &__heading {
     display: flex;
     justify-content: space-between;
+    align-items: center;
   }
 
   &__title {
@@ -298,7 +299,6 @@ export default {
     @include a-text-explanation-small();
     margin-left: 16px;
     white-space: nowrap;
-    margin-top: 4px;
   }
 
   &__badge {

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -301,8 +301,7 @@ export default {
     @include a-text-explanation-small();
     margin-left: 16px;
     white-space: nowrap;
-    top: 16px;
-    right: 16px;
+    margin-top: 4px;
   }
 
   &__badge {


### PR DESCRIPTION
![image](https://github.com/Adamant-im/adamant-im/assets/25831507/497b78ef-938b-4978-a8e4-f15086f14de7)

Resolves https://trello.com/c/yRtWY0uF/433-ui-reduce-name-field-size-in-the-chat-list-screen
