### PR TITLE
feat(Transaction): show inconsistent status if it's a duplicate

### DIFF
--- a/src/mixins/transaction.js
+++ b/src/mixins/transaction.js
@@ -126,6 +126,23 @@ export default {
           return status
         }
 
+        const partnerId =
+          admSpecialMessage.recipientId === this.$store.state.address
+            ? admSpecialMessage.senderId
+            : admSpecialMessage.recipientId
+        const messages = this.$store.getters['chat/messages'](partnerId)
+        const originalTxIndex = messages.findIndex(
+          (message) => message.hash === admSpecialMessage.hash
+        )
+        const currentTxIndex = messages.indexOf(admSpecialMessage)
+        const isDuplicate = originalTxIndex !== currentTxIndex
+        if (isDuplicate) {
+          status.status = TS.INVALID
+          status.virtualStatus = TS.INVALID
+
+          return status
+        }
+
         const getterName = type.toLowerCase() + '/transaction'
         const getter = this.$store.getters[getterName]
         if (!getter) return status

--- a/src/store/modules/chat/index.js
+++ b/src/store/modules/chat/index.js
@@ -385,19 +385,6 @@ const mutations = {
       return
     }
 
-    // Shouldn't duplicate third-party crypto transactions
-    if (
-      message.type &&
-      message.type !== 'message' &&
-      message.type !== 'reaction' &&
-      message.type !== Cryptos.ADM
-    ) {
-      const localTransaction = chat.messages.find(
-        (localTransaction) => localTransaction.hash === message.hash
-      )
-      if (localTransaction) return
-    }
-
     // use unshift when loading chat history
     if (unshift) {
       chat.messages.unshift(message)


### PR DESCRIPTION
Show inconsistent status for duplicate crypto transactions instead of hiding duplicates.

![image](https://github.com/Adamant-im/adamant-im/assets/25831507/ecd2ce01-91db-42cf-9a46-d15d32965c63)

Here is another [task](https://trello.com/c/T0lBJNp9/464-refactor-transactionjs-mixin) for refactoring the transaction mixin. Now it looks complicated. This PR can be considered as an workaround.