### PR TITLE
fix: Show same error message when starting a new chat with incorrect ADM address

### DIFF
--- a/src/components/ChatStartDialog.vue
+++ b/src/components/ChatStartDialog.vue
@@ -178,7 +178,7 @@ export default {
           e.preventDefault()
           this.getInfoFromURI(data)
         } else {
-          this.$emit('error', this.$t('transfer.error_incorrect_address', { crypto: 'ADM' }))
+          this.$emit('error', this.$t('chats.incorrect_address'))
         }
       })
     },


### PR DESCRIPTION

![Screenshot 2023-12-29 10 07 18](https://github.com/Adamant-im/adamant-im/assets/122323015/21d234da-6008-4aa2-811b-137ca584fbd4)
