### PR TITLE
fix: emojis are not visible on iOS Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "serve": "vite preview --config vite-pwa.config.ts",
-    "dev": "vite --config vite-pwa.config.ts",
+    "dev": "vite --host 0.0.0.0 --config vite-pwa.config.ts",
     "serve:test": "cross-env ADM_CONFIG_FILE=test vue-cli-service serve",
     "wallets:generate": "npm run wallets:data:generate && npm run wallets:types:generate",
     "wallets:data:generate": "node scripts/wallets.mjs",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "private": true,
   "scripts": {
     "serve": "vite preview --config vite-pwa.config.ts",
-    "dev": "vite --host 0.0.0.0 --config vite-pwa.config.ts",
+    "dev": "vite --config vite-pwa.config.ts",
+    "dev:localnet": "vite --host 0.0.0.0 --config vite-pwa.config.ts",
     "serve:test": "cross-env ADM_CONFIG_FILE=test vue-cli-service serve",
     "wallets:generate": "npm run wallets:data:generate && npm run wallets:types:generate",
     "wallets:data:generate": "node scripts/wallets.mjs",

--- a/src/components/Chat/Chat.vue
+++ b/src/components/Chat/Chat.vue
@@ -52,6 +52,7 @@
               v-if="showEmojiPicker"
               @emoji:select="(emoji) => onEmojiSelect(actionMessage.id, emoji)"
               elevation
+              position="absolute"
             />
 
             <AChatReactionSelect
@@ -119,6 +120,7 @@
                   v-if="showEmojiPicker"
                   @emoji:select="(emoji) => onEmojiSelect(message.id, emoji)"
                   elevation
+                  position="absolute"
                 />
 
                 <AChatReactionSelect
@@ -175,6 +177,7 @@
                   v-if="showEmojiPicker"
                   @emoji:select="(emoji) => onEmojiSelect(message.id, emoji)"
                   elevation
+                  position="absolute"
                 />
 
                 <AChatReactionSelect

--- a/src/components/Chat/ChatEmojis.vue
+++ b/src/components/Chat/ChatEmojis.vue
@@ -2,6 +2,7 @@
   <v-menu
     :model-value="open"
     :eager="true"
+    location="top"
     @update:model-value="toggleMenu"
     :close-on-content-click="false"
     transition="slide-y-reverse-transition"

--- a/src/components/Chat/ChatEmojis.vue
+++ b/src/components/Chat/ChatEmojis.vue
@@ -11,7 +11,7 @@
       <v-icon class="chat-emojis__icon" icon="mdi-emoticon-outline" size="28" v-bind="props" />
     </template>
 
-    <emoji-picker @emoji:select="getEmoji"></emoji-picker>
+    <emoji-picker @emoji:select="getEmoji" position="absolute"></emoji-picker>
   </v-menu>
 </template>
 <script>

--- a/src/components/Chat/ChatMenu.vue
+++ b/src/components/Chat/ChatMenu.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <v-menu>
+    <v-menu eager>
       <template #activator="{ props }">
         <v-icon class="chat-menu__icon" v-bind="props" icon="mdi-plus-circle-outline" size="28" />
       </template>

--- a/src/components/Chat/ChatMenu.vue
+++ b/src/components/Chat/ChatMenu.vue
@@ -144,6 +144,7 @@ export default {
 .chat-menu {
   &__list {
     min-width: 200px;
+    max-height: 100vh;
 
     :deep(.v-list-item-title) {
       font-weight: 400;

--- a/src/components/EmojiPicker.vue
+++ b/src/components/EmojiPicker.vue
@@ -2,6 +2,7 @@
   <div
     :class="{
       [classes.root]: true,
+      [classes.positionAbsolute]: position === 'absolute',
       'elevation-9': elevation
     }"
   >
@@ -12,19 +13,23 @@
 <script lang="ts">
 import { useTheme } from '@/hooks/useTheme'
 import axios from 'axios'
-import { defineComponent, onMounted, ref } from 'vue'
+import { defineComponent, onMounted, PropType, ref } from 'vue'
 import { Picker } from 'emoji-mart'
 import { isMobile } from '@/lib/display-mobile'
 
 const className = 'emoji-picker'
 const classes = {
-  root: className
+  root: className,
+  positionAbsolute: `${className}--position-absolute`
 }
 
 export default defineComponent({
   props: {
     elevation: {
       type: Boolean
+    },
+    position: {
+      type: String as PropType<'absolute'>
     }
   },
   emits: ['emoji:select'],
@@ -66,11 +71,14 @@ export default defineComponent({
 <style lang="scss">
 @import 'vuetify/settings';
 
-//Fix for Chrome on iOS. Don't touch it
 .emoji-picker {
   border-radius: 8px;
-  position: absolute;
-  bottom: 0;
+
+  &--position-absolute {
+    // Fix for Chrome on iOS. Don't touch it
+    position: absolute;
+    bottom: 0;
+  }
 
   em-emoji-picker {
     width: 264px;

--- a/src/components/EmojiPicker.vue
+++ b/src/components/EmojiPicker.vue
@@ -66,6 +66,7 @@ export default defineComponent({
 <style lang="scss">
 @import 'vuetify/settings';
 
+//Fix for Chrome on iOS. Don't touch it
 .emoji-picker {
   border-radius: 8px;
   position: absolute;

--- a/src/components/EmojiPicker.vue
+++ b/src/components/EmojiPicker.vue
@@ -68,6 +68,8 @@ export default defineComponent({
 
 .emoji-picker {
   border-radius: 8px;
+  position: absolute;
+  bottom: 0;
 
   em-emoji-picker {
     width: 264px;


### PR DESCRIPTION
Fix for hidden emojis selector on Chrome (iOS
![image (8)](https://github.com/Adamant-im/adamant-im/assets/39791681/fa7c4001-ace5-461f-a8c4-c81aa78587a9)
