### PR TITLE
fix: commands shouldn't be in ASC order

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -94,6 +94,7 @@
         "@types/dompurify": "^3.0.5",
         "@types/emoji-mart": "^3.0.14",
         "@types/eslint": "^8.56.6",
+        "@types/lodash": "^4.17.0",
         "@types/pbkdf2": "^3.1.2",
         "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^7.3.1",
@@ -4769,6 +4770,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.17.0",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.0.tgz",
+      "integrity": "sha512-t7dhREVv6dbNj0q17X12j7yDG4bD/DHYX7o5/DbDxobP0HnGPgpRz2Ej77aL7TZT3DSw13fqUTj8J4mMnqa7WA==",
+      "dev": true
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "@types/dompurify": "^3.0.5",
     "@types/emoji-mart": "^3.0.14",
     "@types/eslint": "^8.56.6",
+    "@types/lodash": "^4.17.0",
     "@types/pbkdf2": "^3.1.2",
     "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^7.3.1",

--- a/src/components/AChat/AChatForm.vue
+++ b/src/components/AChat/AChatForm.vue
@@ -230,6 +230,8 @@ export default {
           message: this.message,
           partnerId: this.partnerId
         })
+        this.botCommandIndex = null
+        this.botCommandSelectionMode = false
       } else {
         this.$emit('error', error)
       }

--- a/src/components/AChat/AChatForm.vue
+++ b/src/components/AChat/AChatForm.vue
@@ -221,7 +221,8 @@ export default {
         if (this.message.startsWith('/')) {
           this.$store.commit('botCommands/addCommand', {
             partnerId: this.partnerId,
-            command: this.message
+            command: this.message.trim(),
+            timestamp: Date.now()
           })
         }
         this.$emit('message', this.message)
@@ -261,7 +262,7 @@ export default {
       if (this.botCommandIndex === null) {
         if (direction === 'ArrowUp') {
           this.botCommandIndex = maxIndex
-          this.message = commands[this.botCommandIndex] || ''
+          this.message = commands[this.botCommandIndex]?.command || ''
         }
         return
       }
@@ -269,14 +270,14 @@ export default {
       if (direction === 'ArrowUp') {
         if (this.botCommandIndex > 0) {
           this.botCommandIndex--
-          this.message = commands[this.botCommandIndex] || ''
+          this.message = commands[this.botCommandIndex]?.command || ''
         }
         return
       }
 
       if (this.botCommandIndex < maxIndex) {
         this.botCommandIndex++
-        this.message = commands[this.botCommandIndex] || ''
+        this.message = commands[this.botCommandIndex]?.command || ''
       }
     }
   }

--- a/src/lodash.uniq.d.ts
+++ b/src/lodash.uniq.d.ts
@@ -1,0 +1,3 @@
+declare module 'lodash' {
+  declare function uniq<T>(s: T[]): T[]
+}

--- a/src/lodash.uniq.d.ts
+++ b/src/lodash.uniq.d.ts
@@ -1,3 +1,0 @@
-declare module 'lodash' {
-  declare function uniq<T>(s: T[]): T[]
-}

--- a/src/store/modules/bot-commands/bot-commands-actions.ts
+++ b/src/store/modules/bot-commands/bot-commands-actions.ts
@@ -5,5 +5,8 @@ import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types
 export const actions: ActionTree<BotCommandsState, RootState> = {
   addBotCommand({ commit }, value: BotCommand): void {
     commit('addCommand', value)
+  },
+  initBotCommands({ commit }, value: { partnerId: string; commands: string[] }): void {
+    commit('initCommands', value)
   }
 }

--- a/src/store/modules/bot-commands/bot-commands-actions.ts
+++ b/src/store/modules/bot-commands/bot-commands-actions.ts
@@ -1,12 +1,28 @@
 import { ActionTree } from 'vuex'
 import { RootState } from '@/store/types'
-import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types.ts'
+import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types'
+import { extractCommandsFromMessages } from '@/store/modules/bot-commands/utils/extractCommandsFromMessages'
+import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
 
 export const actions: ActionTree<BotCommandsState, RootState> = {
   addBotCommand({ commit }, value: BotCommand): void {
     commit('addCommand', value)
   },
-  initBotCommands({ commit }, value: { partnerId: string; commands: string[] }): void {
-    commit('initCommands', value)
+  reInitCommands({ commit }, messages: NormalizedChatMessageTransaction[]) {
+    if (messages && messages.length > 0) {
+      const chats = Object.groupBy(messages, ({ recipientId }) => recipientId)
+      for (const recipientId in chats) {
+        const chatMessages = chats[recipientId]
+        if (Array.isArray(chatMessages)) {
+          const commands = extractCommandsFromMessages(recipientId, chatMessages)
+          if (commands.length > 0) {
+            commit('initCommands', {
+              partnerId: recipientId,
+              commands
+            })
+          }
+        }
+      }
+    }
   }
 }

--- a/src/store/modules/bot-commands/bot-commands-getters.ts
+++ b/src/store/modules/bot-commands/bot-commands-getters.ts
@@ -1,6 +1,6 @@
 import { GetterTree } from 'vuex'
 import { RootState } from '@/store/types'
-import { BotCommandsState } from '@/store/modules/bot-commands/types.ts'
+import { BotCommandsState } from '@/store/modules/bot-commands/types'
 
 export const getters: GetterTree<BotCommandsState, RootState> = {
   getCommandsHistory: (state) => (parentId: string) => {

--- a/src/store/modules/bot-commands/bot-commands-mutations.ts
+++ b/src/store/modules/bot-commands/bot-commands-mutations.ts
@@ -1,6 +1,6 @@
 import { MutationTree } from 'vuex'
-import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types.ts'
-import { uniqCommand } from '@/store/modules/bot-commands/utils/uniqCommand.ts'
+import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types'
+import { uniqCommand } from '@/store/modules/bot-commands/utils/uniqCommand'
 
 export const mutations: MutationTree<BotCommandsState> = {
   addCommand(state, botCommand: BotCommand & { partnerId: string }): void {

--- a/src/store/modules/bot-commands/bot-commands-mutations.ts
+++ b/src/store/modules/bot-commands/bot-commands-mutations.ts
@@ -1,27 +1,32 @@
 import { MutationTree } from 'vuex'
 import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types.ts'
-import { uniq } from 'lodash'
+import { uniqCommand } from '@/store/modules/bot-commands/utils/uniqCommand.ts'
 
 export const mutations: MutationTree<BotCommandsState> = {
-  addCommand(state, botCommand: BotCommand): void {
-    const commandValue = botCommand.command.trim()
+  addCommand(state, botCommand: BotCommand & { partnerId: string }): void {
     let botCommands = state.commands[botCommand.partnerId]
     if (!botCommands) {
-      botCommands = [commandValue]
+      botCommands = [botCommand]
     } else {
-      const index = botCommands.indexOf(commandValue)
+      const index = botCommands.findIndex((item) => item.command === botCommand.command)
       if (index >= 0) {
         botCommands.splice(index, 1)
       }
-      botCommands.push(commandValue)
+      botCommands.push(botCommand)
     }
     state.commands[botCommand.partnerId] = botCommands
   },
 
-  initCommands(state, { partnerId, commands }: { partnerId: string; commands: string[] }): void {
-    const botCommands = state.commands[partnerId]
-    if (!botCommands) {
-      state.commands[partnerId] = uniq(commands)
-    }
+  initCommands(
+    state,
+    { partnerId, commands }: { partnerId: string; commands: BotCommand[] }
+  ): void {
+    const existsCommand = state.commands[partnerId] || []
+    state.commands[partnerId] = uniqCommand([...existsCommand, ...commands]).sort((a, b) => {
+      const diff = a.timestamp - b.timestamp
+      if (diff < 0) return -1
+      if (diff > 0) return 1
+      return 0
+    })
   }
 }

--- a/src/store/modules/bot-commands/bot-commands-mutations.ts
+++ b/src/store/modules/bot-commands/bot-commands-mutations.ts
@@ -1,5 +1,6 @@
 import { MutationTree } from 'vuex'
 import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types.ts'
+import { uniq } from 'lodash'
 
 export const mutations: MutationTree<BotCommandsState> = {
   addCommand(state, botCommand: BotCommand): void {
@@ -15,5 +16,12 @@ export const mutations: MutationTree<BotCommandsState> = {
       botCommands.push(commandValue)
     }
     state.commands[botCommand.partnerId] = botCommands
+  },
+
+  initCommands(state, { partnerId, commands }: { partnerId: string; commands: string[] }): void {
+    const botCommands = state.commands[partnerId]
+    if (!botCommands) {
+      state.commands[partnerId] = uniq(commands)
+    }
   }
 }

--- a/src/store/modules/bot-commands/bot-commands-mutations.ts
+++ b/src/store/modules/bot-commands/bot-commands-mutations.ts
@@ -4,11 +4,16 @@ import { BotCommand, BotCommandsState } from '@/store/modules/bot-commands/types
 export const mutations: MutationTree<BotCommandsState> = {
   addCommand(state, botCommand: BotCommand): void {
     const commandValue = botCommand.command.trim()
-    const botCommands = state.commands[botCommand.partnerId]
+    let botCommands = state.commands[botCommand.partnerId]
     if (!botCommands) {
-      state.commands[botCommand.partnerId] = [commandValue]
-    } else if (!botCommands.includes(commandValue)) {
+      botCommands = [commandValue]
+    } else {
+      const index = botCommands.indexOf(commandValue)
+      if (index >= 0) {
+        botCommands.splice(index, 1)
+      }
       botCommands.push(commandValue)
     }
+    state.commands[botCommand.partnerId] = botCommands
   }
 }

--- a/src/store/modules/bot-commands/bot-commands-state.ts
+++ b/src/store/modules/bot-commands/bot-commands-state.ts
@@ -1,4 +1,4 @@
-import { BotCommandsState } from '@/store/modules/bot-commands/types.ts'
+import { BotCommandsState } from '@/store/modules/bot-commands/types'
 
 export const state: BotCommandsState = {
   commands: {}

--- a/src/store/modules/bot-commands/index.ts
+++ b/src/store/modules/bot-commands/index.ts
@@ -1,10 +1,10 @@
-import { actions } from './bot-commands-actions.ts'
-import { mutations } from './bot-commands-mutations.ts'
-import { state } from './bot-commands-state.ts'
-import { getters } from './bot-commands-getters.ts'
+import { actions } from './bot-commands-actions'
+import { mutations } from './bot-commands-mutations'
+import { state } from './bot-commands-state'
+import { getters } from './bot-commands-getters'
 import { Module } from 'vuex'
 import { RootState } from '@/store/types'
-import { BotCommandsState } from '@/store/modules/bot-commands/types.ts'
+import { BotCommandsState } from '@/store/modules/bot-commands/types'
 
 const bodCommandsModule: Module<BotCommandsState, RootState> = {
   namespaced: true,

--- a/src/store/modules/bot-commands/types.ts
+++ b/src/store/modules/bot-commands/types.ts
@@ -1,5 +1,5 @@
 export interface BotCommandsState {
-  commands: Record<string, string[]>
+  commands: Record<string, BotCommand[]>
 }
 
-export type BotCommand = { partnerId: string; command: string }
+export type BotCommand = { command: string; timestamp: number }

--- a/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
+++ b/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
@@ -1,0 +1,16 @@
+import { getRealTimestamp } from '@/lib/chat/helpers/utils/getRealTimestamp'
+import { BotCommand } from '@/store/modules/bot-commands/types.ts'
+
+export function extractCommandsFromMessages(
+  recipientId: string,
+  messages: { message: any; timestamp: number; recipientId: string }[]
+): BotCommand[] {
+  return messages
+    .filter((item) => item.recipientId === recipientId)
+    .filter((item) => typeof item.message === 'string')
+    .filter((item) => item.message?.startsWith('/'))
+    .map((item) => ({
+      command: item.message.trim(),
+      timestamp: getRealTimestamp(item.timestamp)
+    }))
+}

--- a/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
+++ b/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
@@ -3,9 +3,9 @@ import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
 
 /**
  * The function retrieves all bot commands from the message array
- * @param {string} recipientId  Message recipient address
- * @param {NormalizedChatMessageTransaction[]} messages Array of normalized messages
- * @return {BotCommand[]} Bot commands array
+ * @param recipientId  Message recipient address
+ * @param messages Array of normalized messages
+ * @return Bot commands array
  * */
 export function extractCommandsFromMessages(
   recipientId: string,

--- a/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
+++ b/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
@@ -1,9 +1,15 @@
-import { getRealTimestamp } from '@/lib/chat/helpers/utils/getRealTimestamp'
-import { BotCommand } from '@/store/modules/bot-commands/types.ts'
+import { BotCommand } from '@/store/modules/bot-commands/types'
+import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
 
+/**
+ * The function retrieves all bot commands from the message array
+ * @param {string} recipientId  Message recipient address
+ * @param {NormalizedChatMessageTransaction[]} messages Array of normalized messages
+ * @return {BotCommand[]} Bot commands array
+ * */
 export function extractCommandsFromMessages(
   recipientId: string,
-  messages: { message: any; timestamp: number; recipientId: string }[]
+  messages: NormalizedChatMessageTransaction[]
 ): BotCommand[] {
   return messages
     .filter((item) => item.recipientId === recipientId)
@@ -11,6 +17,6 @@ export function extractCommandsFromMessages(
     .filter((item) => item.message?.startsWith('/'))
     .map((item) => ({
       command: item.message.trim(),
-      timestamp: getRealTimestamp(item.timestamp)
+      timestamp: item.timestamp
     }))
 }

--- a/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
+++ b/src/store/modules/bot-commands/utils/extractCommandsFromMessages.ts
@@ -12,9 +12,12 @@ export function extractCommandsFromMessages(
   messages: NormalizedChatMessageTransaction[]
 ): BotCommand[] {
   return messages
-    .filter((item) => item.recipientId === recipientId)
-    .filter((item) => typeof item.message === 'string')
-    .filter((item) => item.message?.startsWith('/'))
+    .filter(
+      (item) =>
+        item.recipientId === recipientId &&
+        typeof item.message === 'string' &&
+        item.message?.startsWith('/')
+    )
     .map((item) => ({
       command: item.message.trim(),
       timestamp: item.timestamp

--- a/src/store/modules/bot-commands/utils/uniqCommand.ts
+++ b/src/store/modules/bot-commands/utils/uniqCommand.ts
@@ -1,0 +1,16 @@
+import { BotCommand } from '@/store/modules/bot-commands/types.ts'
+
+export function uniqCommand(commands: BotCommand[]) {
+  const result: BotCommand[] = []
+  for (const currentCommand of commands) {
+    const index = result.findIndex((item) => item.command === currentCommand.command)
+    if (index === -1) {
+      result.push(currentCommand)
+      continue
+    }
+    if (result[index].timestamp < currentCommand.timestamp) {
+      result[index] = currentCommand
+    }
+  }
+  return result
+}

--- a/src/store/modules/bot-commands/utils/uniqCommand.ts
+++ b/src/store/modules/bot-commands/utils/uniqCommand.ts
@@ -3,8 +3,8 @@ import { BotCommand } from '@/store/modules/bot-commands/types'
 /**
  * The function returns an array of unique bot commands.
  * If a duplicate is detected, the function gives preference to the one with the larger timestamp.
- * @param {BotCommand[]} commands Bot commands array
- * @return {BotCommand[]} An array of unique bot commands
+ * @param commands Bot commands array
+ * @return An array of unique bot commands
  * */
 export function uniqCommand(commands: BotCommand[]) {
   const result: BotCommand[] = []

--- a/src/store/modules/bot-commands/utils/uniqCommand.ts
+++ b/src/store/modules/bot-commands/utils/uniqCommand.ts
@@ -1,5 +1,11 @@
-import { BotCommand } from '@/store/modules/bot-commands/types.ts'
+import { BotCommand } from '@/store/modules/bot-commands/types'
 
+/**
+ * The function returns an array of unique bot commands.
+ * If a duplicate is detected, the function gives preference to the one with the larger timestamp.
+ * @param {BotCommand[]} commands Bot commands array
+ * @return {BotCommand[]} An array of unique bot commands
+ * */
 export function uniqCommand(commands: BotCommand[]) {
   const result: BotCommand[] = []
   for (const currentCommand of commands) {

--- a/src/store/modules/chat/index.js
+++ b/src/store/modules/chat/index.js
@@ -558,6 +558,20 @@ const actions = {
       .then(({ messages, lastOffset }) => {
         dispatch('unshiftMessages', messages)
 
+        if (messages && offset === 0) {
+          dispatch(
+            'botCommands/initBotCommands',
+            {
+              partnerId: contactId,
+              commands: messages
+                .filter((item) => item.message.startsWith('/'))
+                .map((item) => item.message.trim())
+                .reverse()
+            },
+            { root: true }
+          )
+        }
+
         if (messages.length <= 0) {
           commit('setChatOffset', { contactId, offset: -1 }) // no more messages
         } else {

--- a/src/store/modules/chat/index.js
+++ b/src/store/modules/chat/index.js
@@ -564,7 +564,7 @@ const actions = {
             {
               partnerId: contactId,
               commands: messages
-                .filter((item) => item.message.startsWith('/'))
+                .filter((item) => item.message?.startsWith('/'))
                 .map((item) => item.message.trim())
                 .reverse()
             },

--- a/src/store/modules/chat/index.js
+++ b/src/store/modules/chat/index.js
@@ -15,7 +15,6 @@ import { isStringEqualCI } from '@/lib/textHelpers'
 import { replyMessageAsset } from '@/lib/adamant-api/asset'
 
 import { generateAdamantChats } from './utils/generateAdamantChats'
-import { extractCommandsFromMessages } from '../bot-commands/utils/extractCommandsFromMessages'
 
 export let interval
 
@@ -575,47 +574,27 @@ const actions = {
    * @param {Message[]} messages Array of messages
    */
   pushMessages({ commit, rootState, dispatch }, messages) {
-    dispatch('reInitCommands', messages)
-    messages.forEach((message) => {
+    const normalizedMessages = messages.map(normalizeMessage)
+    dispatch('botCommands/reInitCommands', normalizedMessages, { root: true })
+    normalizedMessages.forEach((message) => {
       commit('pushMessage', {
-        message: normalizeMessage(message),
+        message: message,
         userId: rootState.address
       })
     })
   },
 
   unshiftMessages({ commit, rootState, dispatch }, messages) {
-    dispatch('reInitCommands', messages)
-    messages.forEach((message) => {
+    const normalizedMessages = messages.map(normalizeMessage)
+    dispatch('botCommands/reInitCommands', normalizedMessages, { root: true })
+    normalizedMessages.forEach((message) => {
       commit('pushMessage', {
-        message: normalizeMessage(message),
+        message: message,
         userId: rootState.address,
 
         unshift: true
       })
     })
-  },
-
-  reInitCommands({ dispatch }, messages) {
-    if (messages && messages.length > 0) {
-      const chats = Object.groupBy(messages, ({ recipientId }) => recipientId)
-      for (const recipientId in chats) {
-        const chatMessages = chats[recipientId]
-        if (Array.isArray(chatMessages)) {
-          const commands = extractCommandsFromMessages(recipientId, chatMessages)
-          if (commands.length > 0) {
-            dispatch(
-              'botCommands/initBotCommands',
-              {
-                partnerId: recipientId,
-                commands
-              },
-              { root: true }
-            )
-          }
-        }
-      }
-    }
   },
 
   /**

--- a/src/store/modules/draft-message/index.ts
+++ b/src/store/modules/draft-message/index.ts
@@ -31,11 +31,17 @@ const mutations: MutationTree<DraftState> = {
   },
 
   deleteReplyTold(state, payload: { partnerId: string; replyToId: string }) {
-    delete state.drafts[payload.partnerId].replyToId
+    const draft = state.drafts[payload.partnerId]
+    if (draft) {
+      delete draft.replyToId
+    }
   },
 
   deleteMessage(state, payload: { partnerId: string; message: string }) {
-    delete state.drafts[payload.partnerId].message
+    const draft = state.drafts[payload.partnerId]
+    if (draft) {
+      delete draft.message
+    }
   },
 
   reset(state) {


### PR DESCRIPTION
https://trello.com/c/oMvsGyEs/527-commands-shouldnt-be-in-asc-order

- The last command entered must be the first in the list.
- Load command history on start

[Screencast from 26.03.2024 15:44:27.webm](https://github.com/Adamant-im/adamant-im/assets/160286261/48a1c6e3-948c-499d-aa4e-5d5b85569616)
