### PR TITLE
fix: scroll between commands only when the input field focused

### DIFF
--- a/src/components/AChat/AChatForm.vue
+++ b/src/components/AChat/AChatForm.vue
@@ -19,6 +19,8 @@
       color="primary"
       v-on="listeners"
       :autofocus="isDesktopDevice"
+      @focusin="isInputFocused = true"
+      @focusout="isInputFocused = false"
     >
       <template #prepend-inner>
         <chat-emojis
@@ -83,7 +85,8 @@ export default {
     message: '',
     emojiPickerOpen: false,
     botCommandIndex: null,
-    botCommandSelectionMode: false
+    botCommandSelectionMode: false,
+    isInputFocused: false
   }),
   computed: {
     isDesktopDevice: () => !isMobile(),
@@ -156,7 +159,7 @@ export default {
     onKeyCommand: function (event) {
       if (event.ctrlKey && event.shiftKey && event.code === 'Digit1') {
         this.openElement()
-      } else if (event.code === 'ArrowUp' || event.code === 'ArrowDown') {
+      } else if (this.isInputFocused && (event.code === 'ArrowUp' || event.code === 'ArrowDown')) {
         this.selectCommand(event.code)
         event.preventDefault()
       } else if (event.key.length === 1) {


### PR DESCRIPTION
Trello: [task]( https://trello.com/c/oMvsGyEs/527-commands-shouldnt-be-in-asc-order)

[fix: scroll between commands .webm](https://github.com/Adamant-im/adamant-im/assets/160286261/9ad38edf-34b4-4b9a-8b13-0a7c8c5e23fc)
