### PR TITLE
fix: Electron for Mac build failed

### DIFF
--- a/.github/workflows/electron-mac.yml
+++ b/.github/workflows/electron-mac.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - dev
+      - fix/electron-for-mac-build-failed
 
 env:
   GH_TOKEN: ${{ secrets.github_token }}

--- a/.github/workflows/electron-mac.yml
+++ b/.github/workflows/electron-mac.yml
@@ -5,7 +5,6 @@ on:
     branches:
       - master
       - dev
-      - fix/electron-for-mac-build-failed
 
 env:
   GH_TOKEN: ${{ secrets.github_token }}

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,7 +37,7 @@ mac:
   gatekeeperAssess: false
   notarize: false
 
-afterPack: 'scripts/electron/notarize.cjs'
+afterSign: 'scripts/electron/notarize.cjs'
 
 # Config for OSX dmg
 dmg:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -37,7 +37,7 @@ mac:
   gatekeeperAssess: false
   notarize: false
 
-afterSign: 'scripts/electron/notarize.cjs'
+afterPack: 'scripts/electron/notarize.cjs'
 
 # Config for OSX dmg
 dmg:

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -35,6 +35,7 @@ mac:
   entitlementsInherit: './build/osx/entitlements.mac.plist'
   hardenedRuntime: true
   gatekeeperAssess: false
+  notarize: false
 
 afterSign: 'scripts/electron/notarize.cjs'
 


### PR DESCRIPTION
- fix: disable `electron-builder` notarization
- fix: try notarization by hook after pack and before sign