### PR TITLE
fix: [vuex] Unknown local action type: checkWalletsOrderBeforeInit

### DIFF
--- a/src/store/modules/wallets/wallets-actions.ts
+++ b/src/store/modules/wallets/wallets-actions.ts
@@ -5,7 +5,6 @@ import { mapWallets } from '@/store/modules/wallets/utils'
 
 export const actions: ActionTree<WalletsState, RootState> = {
   initWalletsSymbols({ dispatch }): void {
-    dispatch('checkWalletsOrderBeforeInit')
     const walletSymbols: CoinSymbol[] = mapWallets()
     dispatch('setWalletSymbols', walletSymbols)
   },


### PR DESCRIPTION
- fix: remove vuex-dispatch of none-existent method `checkWalletsOrderBeforeInit`