### PR TITLE
Allow HTTP nodes in Android app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/AppTheme">
         <activity
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|locale|smallestScreenSize|screenLayout|uiMode"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <!-- Domains below will bypass cleartext (mixed content) policy -->
+    <domain includeSubdomains="true">54.197.36.175</domain>
+    <domain includeSubdomains="true">amazonaws.com</domain>
+  </domain-config>
+</network-security-config>

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -11,6 +11,14 @@ const config: CapacitorConfig = {
     SplashScreen: {
       androidScaleType: 'CENTER_CROP' // fix logo stretching
     }
+  },
+  android: {
+    // This option allows making requests from HTTPS to HTTP.
+    // Android 9.0 (Pie) introduced restrictions on cleartext (HTTP) traffic, which is enabled by default.
+    // Even allowing mixed content, the app will still block these requests due to cleartext restrictions.
+    // To bypass this, we have a whitelist of HTTP domains/IPs.
+    // See android/app/src/main/res/xml/network_security_config.xml
+    allowMixedContent: true
   }
 }
 

--- a/src/lib/nodes/abstract.node.ts
+++ b/src/lib/nodes/abstract.node.ts
@@ -112,7 +112,7 @@ export abstract class Node<C = unknown> {
     this.hostname = new URL(url).hostname
     this.minNodeVersion = minNodeVersion
     this.version = version
-    this.hasSupportedProtocol = !(this.protocol === 'http:' && appProtocol === 'https:')
+    this.hasSupportedProtocol = true // @todo add option: Enable HTTP nodes
     this.active = nodesStorage.isActive(url)
 
     this.client = this.buildClient()


### PR DESCRIPTION
- Allow mixed content (HTTPS -> HTTP)
- Created a whitelist of HTTP nodes