### PR TITLE
fix: app not working when disabling ADM nodes and refreshing

### DIFF
--- a/src/store/modules/chat/index.js
+++ b/src/store/modules/chat/index.js
@@ -543,6 +543,7 @@ const actions = {
       .catch((err) => {
         if (isAllNodesDisabledError(err) || isAllNodesOfflineError(err)) {
           commit('setNoActiveNodesDialog', true)
+          commit('setFulfilled', true)
           setTimeout(() => dispatch('loadChats'), 5000) // retry in 5 seconds
         }
       })


### PR DESCRIPTION
https://trello.com/c/UYbbJ8fm/593-bug-the-application-does-not-work-after-disabling-adm-nodes

When trying to load chats, it's possible that the user has turned all the nodes off, in that case we should set isFulfilled=true because otherwise there will a be a layer of loading that's blocking the entire interface in the chat room. So I basically allowed a user to exit the chatroom to enable some of ADM nodes in case he accidentaly closed the 'enable ADM nodes' pop up.
Correct me if that solution is wrong or might lead to some improper app work.