### PR TITLE
chore: use the same style for back button as it was in chat room

### DIFF
--- a/src/components/AppToolbarCentered.vue
+++ b/src/components/AppToolbarCentered.vue
@@ -3,10 +3,7 @@
     <v-row justify="center" no-gutters>
       <container>
         <v-toolbar ref="toolbar" :flat="flat" :height="height">
-          <v-btn v-if="showBack" icon @click="goBack">
-            <v-icon :icon="mdiArrowLeft" />
-          </v-btn>
-
+          <back-button v-if="showBack" :go-back="goBack" />
           <v-toolbar-title v-if="title" class="a-text-regular-enlarged">
             <div>{{ title }}</div>
             <div v-if="subtitle" class="body-1">
@@ -21,8 +18,10 @@
 
 <script>
 import { mdiArrowLeft } from '@mdi/js'
+import BackButton from '@/components/common/BackButton/BackButton.vue'
 
 export default {
+  components: { BackButton },
   props: {
     title: {
       type: String,
@@ -95,24 +94,6 @@ export default {
 
   :deep(.v-toolbar-title:not(:first-child)) {
     margin-inline-start: 0;
-  }
-
-  :deep(.v-toolbar__content > .v-btn:first-child) {
-    margin-inline-start: 4px;
-  }
-
-  :deep(.v-toolbar__content > .v-btn:first-child) {
-    width: 36px;
-    height: 36px;
-    margin: 0 12px;
-    border-radius: 50%;
-  }
-
-  :deep(.v-btn) {
-    &:hover > .v-btn__overlay {
-      opacity: 0.2;
-      transition: all 0.4s ease;
-    }
   }
 }
 

--- a/src/components/AppToolbarCentered.vue
+++ b/src/components/AppToolbarCentered.vue
@@ -3,7 +3,7 @@
     <v-row justify="center" no-gutters>
       <container>
         <v-toolbar ref="toolbar" :flat="flat" :height="height">
-          <back-button v-if="showBack" :go-back="goBack" />
+          <back-button v-if="showBack" @click="goBack" />
           <v-toolbar-title v-if="title" class="a-text-regular-enlarged">
             <div>{{ title }}</div>
             <div v-if="subtitle" class="body-1">

--- a/src/components/AppToolbarCentered.vue
+++ b/src/components/AppToolbarCentered.vue
@@ -3,8 +3,8 @@
     <v-row justify="center" no-gutters>
       <container>
         <v-toolbar ref="toolbar" :flat="flat" :height="height">
-          <v-btn v-if="showBack" icon size="small" @click="goBack">
-            <v-icon :icon="mdiArrowLeft" size="x-large" />
+          <v-btn v-if="showBack" icon @click="goBack">
+            <v-icon :icon="mdiArrowLeft" />
           </v-btn>
 
           <v-toolbar-title v-if="title" class="a-text-regular-enlarged">
@@ -101,9 +101,17 @@ export default {
     margin-inline-start: 4px;
   }
 
-  :deep(.v-btn:hover) {
-    > .v-btn__overlay {
-      opacity: 0;
+  :deep(.v-toolbar__content > .v-btn:first-child) {
+    width: 36px;
+    height: 36px;
+    margin: 0 12px;
+    border-radius: 50%;
+  }
+
+  :deep(.v-btn) {
+    &:hover > .v-btn__overlay {
+      opacity: 0.2;
+      transition: all 0.4s ease;
     }
   }
 }

--- a/src/components/Chat/ChatToolbar.vue
+++ b/src/components/Chat/ChatToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-toolbar flat height="56" :class="`${className}`" color="transparent">
-    <back-button :go-back="goBack">
+    <back-button @click="goBack">
       <v-badge
         v-if="numOfNewMessages > 0"
         :value="numOfNewMessages"

--- a/src/components/Chat/ChatToolbar.vue
+++ b/src/components/Chat/ChatToolbar.vue
@@ -1,6 +1,6 @@
 <template>
   <v-toolbar flat height="56" :class="`${className}`" color="transparent">
-    <v-btn icon @click="goBack">
+    <back-button :go-back="goBack">
       <v-badge
         v-if="numOfNewMessages > 0"
         :value="numOfNewMessages"
@@ -9,8 +9,7 @@
         :content="numOfNewMessages > 99 ? '99+' : numOfNewMessages"
       >
       </v-badge>
-      <v-icon :icon="mdiArrowLeft" />
-    </v-btn>
+    </back-button>
     <div v-if="!isWelcomeChat(partnerId)">
       <slot name="avatar-toolbar" />
     </div>
@@ -44,8 +43,10 @@
 import partnerName from '@/mixins/partnerName'
 import { isAdamantChat, isWelcomeChat } from '@/lib/chat/meta/utils'
 import { mdiArrowLeft } from '@mdi/js'
+import BackButton from '@/components/common/BackButton/BackButton.vue'
 
 export default {
+  components: { BackButton },
   mixins: [partnerName],
   props: {
     partnerId: {
@@ -140,13 +141,6 @@ export default {
     }
   }
 
-  :deep(.v-toolbar__content > .v-btn:first-child) {
-    width: 36px;
-    height: 36px;
-    margin: 0 12px;
-    border-radius: 50%;
-  }
-
   :deep(.v-text-field) {
     @include mixins.a-text-regular-enlarged-bold();
 
@@ -179,13 +173,6 @@ export default {
 
     .v-input__control > .v-input__slot {
       margin-bottom: 0;
-    }
-  }
-
-  :deep(.v-btn) {
-    &:hover > .v-btn__overlay {
-      opacity: 0.2;
-      transition: all 0.4s ease;
     }
   }
 }

--- a/src/components/common/BackButton/BackButton.vue
+++ b/src/components/common/BackButton/BackButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn :class="className" icon @click="goBack">
+  <v-btn :class="className" icon>
     <slot />
     <v-icon :icon="mdiArrowLeft" />
   </v-btn>

--- a/src/components/common/BackButton/BackButton.vue
+++ b/src/components/common/BackButton/BackButton.vue
@@ -1,0 +1,30 @@
+<template>
+  <v-btn class="back-button" icon @click="goBack">
+    <slot />
+    <v-icon :icon="mdiArrowLeft" />
+  </v-btn>
+</template>
+
+<script setup lang="ts">
+import { mdiArrowLeft } from '@mdi/js'
+
+defineProps<{
+  goBack: () => void
+}>()
+</script>
+
+<style lang="scss">
+.back-button {
+  &:first-child {
+    width: 36px;
+    height: 36px;
+    margin: 0 12px !important;
+    border-radius: 50%;
+  }
+
+  &:hover > .v-btn__overlay {
+    opacity: 0.2;
+    transition: all 0.4s ease;
+  }
+}
+</style>

--- a/src/components/common/BackButton/BackButton.vue
+++ b/src/components/common/BackButton/BackButton.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-btn class="back-button" icon @click="goBack">
+  <v-btn :class="className" icon @click="goBack">
     <slot />
     <v-icon :icon="mdiArrowLeft" />
   </v-btn>
@@ -8,9 +8,7 @@
 <script setup lang="ts">
 import { mdiArrowLeft } from '@mdi/js'
 
-defineProps<{
-  goBack: () => void
-}>()
+const className = 'back-button'
 </script>
 
 <style lang="scss">


### PR DESCRIPTION
Every single page mentioned in this task - https://trello.com/c/ZEobk2Jg/748-ui-use-same-style-back-arrows-on-different-screens uses the same component with a 'back' button, so it was enough to change this button there.