### PR TITLE
fix: potential fix favicon error in console on chat page

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ overscroll-behavior-y: contain;  -->
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="apple-itunes-app" content="app-id=1341473829">
-  <link rel="icon" href="favicon.ico">
+  <link rel="icon" href="/favicon.ico">
   <link rel="mask-icon" href="/img/icons/safari-pinned-tab.svg" color="#5bbad5">
   <link rel="apple-touch-icon-precomposed" sizes="57x57" href="/img/icons/apple-touch-icon-57x57.png" />
   <link rel="apple-touch-icon-precomposed" sizes="114x114" href="/img/icons/apple-touch-icon-114x114.png" />


### PR DESCRIPTION
Mark fix as potential as I didn't manage to recreate the bug on localhost. So I can't check whether it really fixes the problem but it looks like it might help.