### PR TITLE
fix: attachments not downloading except for the first one

### DIFF
--- a/src/components/AChat/AChatAttachment/AChatFile.vue
+++ b/src/components/AChat/AChatAttachment/AChatFile.vue
@@ -80,7 +80,6 @@ import IconFile from '@/components/icons/common/IconFile.vue'
 import { useStore } from 'vuex'
 import { AChatFileLoader } from './AChatFileLoader'
 import { mdiImageOff } from '@mdi/js'
-import { useConsiderOffline } from '@/hooks/useConsiderOffline'
 
 const className = 'a-chat-file'
 const classes = {
@@ -121,9 +120,6 @@ const isImage = computed(() => {
   return ['jpg', 'jpeg', 'png'].includes(props.file.extension!)
 })
 
-const { consideredOffline } = useConsiderOffline()
-
-
 const fileName = computed(() =>
   isLocalFile(props.file) ? props.file.file.name : props.file.name || 'UNNAMED'
 )
@@ -150,10 +146,6 @@ const fileSize = computed(() => {
 
 const uploadProgress = computed(() => {
   if (isLocalFile(props.file)) {
-    if (consideredOffline.value) {
-      return 0;
-    }
-
     return store.getters['attachment/getUploadProgress'](props.file.file.cid)
   }
 

--- a/src/hooks/useResendPendingMessages.ts
+++ b/src/hooks/useResendPendingMessages.ts
@@ -9,6 +9,7 @@ type PendingMessage = {
   timeout: ReturnType<typeof setTimeout>
   type: number
   files?: FileData[]
+  cids?: [string, string | undefined][]
 }
 
 export function useResendPendingMessages() {
@@ -48,6 +49,7 @@ export function useResendPendingMessages() {
           .dispatch('chat/resendAttachment', {
             recipientId: msg.recipientId,
             files: msg.files,
+            cids: msg.cids,
             messageId: id
           })
           .then((res) => {

--- a/src/lib/adamant-api/asset.ts
+++ b/src/lib/adamant-api/asset.ts
@@ -201,23 +201,21 @@ export interface AttachmentAsset {
  * AIP-18: https://github.com/Adamant-im/AIPs/pull/54/files
  * @param {Array<FileData>} files
  * @param {string} [comment] Optional comment associated with the transaction
- * @param {Array<[string]>} [cids] List of files IDs after uploading to IPFS. ID of original file and ID of preview go one by one.
+ * @param {Array<[string, string]>} [cids] List of files IDs after uploading to IPFS. First element is the ID of original file, second is ID of preview.
  */
 export function attachmentAsset(
   files: FileData[],
   comment?: string,
-  cids?: string[]
+  cids?: [string, string][]
 ): AttachmentAsset {
   return {
     files: files.map(({ file, width, height, cid, preview, encoded }, index) => {
-      const cidsChunk = index * 2
-
       const name = extractFileName(file.name)
       const extension = extractFileExtension(file.name)!
       const resolution: FileAsset['resolution'] = width && height ? [width, height] : undefined
 
-      const fileCid = (cids && cids[cidsChunk]) || cid
-      const previewCid = (cids && cids[cidsChunk + 1]) || preview?.cid
+      const fileCid = cids?.[index]?.[0] || cid
+      const previewCid = cids?.[index]?.[1] || preview?.cid
 
       return {
         mimeType: file.type,

--- a/src/lib/files/upload.ts
+++ b/src/lib/files/upload.ts
@@ -1,20 +1,15 @@
 import { FileData } from './types'
 import ipfs from '@/lib/nodes/ipfs'
 
-export async function uploadFiles(
-  files: FileData[],
-  onUploadProgress?: (progress: number) => void
-) {
+export async function uploadFile(file: FileData, onUploadProgress?: (progress: number) => void) {
   const formData = new FormData()
 
-  for (const file of files) {
-    const blob = new Blob([file.encoded.binary], { type: 'application/octet-stream' })
-    formData.append('files', blob, file.file.name)
+  const blob = new Blob([file.encoded.binary], { type: 'application/octet-stream' })
+  formData.append('files', blob, file.file.name)
 
-    if (file.preview) {
-      const blob = new Blob([file.preview.encoded.binary], { type: 'application/octet-stream' })
-      formData.append('files', blob, 'preview-' + file.file.name)
-    }
+  if (file.preview) {
+    const blob = new Blob([file.preview.encoded.binary], { type: 'application/octet-stream' })
+    formData.append('files', blob, 'preview-' + file.file.name)
   }
 
   onUploadProgress?.(0) // set initial progress to 0


### PR DESCRIPTION
When sending a message with multiple files, they couldn't be downloaded except for the first one.
Now it's fixed and files also are uplaoded consistently (and files that were uploaded successfully do not reupload after connection is back)