### PR TITLE
fix: fix black overflow when light theme is turned on

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,9 @@ setLocale()
 </script>
 
 <style lang="scss" scoped>
+@use 'sass:map';
 @use '@/assets/styles/themes/adamant/_mixins.scss';
+@use '@/assets/styles/generic/_variables.scss';
 
 .application--main {
   flex: none;
@@ -91,6 +93,7 @@ setLocale()
   height: calc(100vh - env(safe-area-inset-bottom) - env(safe-area-inset-top));
   height: calc(100dvh - env(safe-area-inset-bottom) - env(safe-area-inset-top));
   margin-top: env(safe-area-inset-top);
+  overflow-y: scroll;
 }
 
 .v-theme--light.application--linear-gradient {


### PR DESCRIPTION
Fix black color overflow when light theme is turned on
<img width="1916" height="873" alt="image" src="https://github.com/user-attachments/assets/82bc8cb6-d45f-4a8b-af08-1fb5c8e6e237" />
