### PR TITLE
:bug: chore: change snackbar location from bottom to center

### DIFF
--- a/src/components/AppSnackbar.vue
+++ b/src/components/AppSnackbar.vue
@@ -5,7 +5,7 @@
     :color="color"
     :class="[className, { outlined: variant === 'outlined' }]"
     :variant="variant"
-    location="bottom"
+    location="center"
     width="100%"
     :multi-line="message.length > 50"
     @click:outside="show = false"


### PR DESCRIPTION
Closes: https://trello.com/c/VAUm1iZX

* Changed snackbar location from "bottom" to "center"

I moved the Snackbar from the bottom to the center of the screen to prevent it from being hidden behind the mobile keyboard. Previously, the default bottom positioning caused visibility issues. The new "center" placement ensures messages remain clearly visible

If you have alternative suggestions for handling this issue, please let me know!

<img width="378" height="659" alt="image" src="https://github.com/user-attachments/assets/878bfbc8-9f10-401b-9799-0958d47502a2" />

