### PR TITLE
ui: replaces text coin to blockchain and fix styles in wallets page

### DIFF
--- a/src/views/Wallets.vue
+++ b/src/views/Wallets.vue
@@ -93,7 +93,7 @@ const wallets = computed(() => {
     const cryptoName = CryptosInfo[symbol].nameShort || CryptosInfo[symbol].name
     const erc20 = isErc20(symbol)
     const isVisible = crypto.isVisible
-    const type = CryptosInfo[symbol].type ?? 'Blockchain'
+    const type = CryptosInfo[symbol].type === 'ERC20' ? CryptosInfo[symbol].type : 'Blockchain'
 
     return {
       cryptoName,
@@ -161,9 +161,13 @@ onBeforeUnmount(() => {
   }
 }
 
+.v-list {
+  border-radius: 8px;
+}
+
 .v-theme--dark {
   .v-list {
-    background-color: map.get(colors.$adm-colors, 'black2');
+    background-color: #323232;
   }
 }
 </style>


### PR DESCRIPTION
- Replaces title "coin" with "blockchain" in wallets page (except for ERC20 coins)
- Fixes background color and border radius in wallets list

<img width="1276" height="871" alt="Untitled" src="https://github.com/user-attachments/assets/d386740d-40c5-4956-a2b2-57d4c033c5f9" />