### PR TITLE
 fix: changes BTS transaction status on rejected in chat when node validation fails

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -5,11 +5,13 @@ All notable changes in this release are listed below.
 ## [Unreleased]
 
 ### New Features
+
 - Test screen for developers is now available [#815](https://github.com/Adamant-im/adamant-im/pull/815) — [@Linhead](https://github.com/Linhead)
 - Universal macOS build added [#840](https://github.com/Adamant-im/adamant-im/pull/840) — [@S-FrontendDev](https://github.com/S-FrontendDev)
 - Release notes file added [#853](https://github.com/Adamant-im/adamant-im/pull/853) — [@S-FrontendDev](https://github.com/S-FrontendDev)
 
 ### Improvements
+
 - APK name changed in GitHub workflow [#839](https://github.com/Adamant-im/adamant-im/pull/839) — [@S-FrontendDev](https://github.com/S-FrontendDev)
 - Wallets UI updated for better usability [#846](https://github.com/Adamant-im/adamant-im/pull/846) — [@Linhead](https://github.com/Linhead), [@adamant-al](https://github.com/adamant-al)
 - ESLint updated to improve code quality [#849](https://github.com/Adamant-im/adamant-im/pull/849) — [@graycraft](https://github.com/graycraft)
@@ -17,7 +19,9 @@ All notable changes in this release are listed below.
 - GitHub Actions workflow and Husky postinstall git hook for ESLint [#858](https://github.com/Adamant-im/adamant-im/pull/858) — [@graycraft](https://github.com/graycraft)
 
 ### Bug Fixes
+
 - Transaction fee calculation for ETH & ERC20 fixed [#805](https://github.com/Adamant-im/adamant-im/pull/805) — [@Linhead](https://github.com/Linhead)
 - Layout issue on "Export keys" page fixed [#841](https://github.com/Adamant-im/adamant-im/pull/841) — [@kalpovskii](https://github.com/kalpovskii), [@adamant-al](https://github.com/adamant-al)
 - Add disabled input field in the Welcome to ADAMANT chat, impoved paddings [#842](https://github.com/Adamant-im/adamant-im/pull/842) — [@kalpovskii](https://github.com/kalpovskii)
 - Resolve source code issues with ESLint 9 [#852](https://github.com/Adamant-im/adamant-im/pull/852) — [@graycraft](https://github.com/graycraft)
+- Fixed status rejected BTC dust transactions in chat when node validation fails [#857](https://github.com/Adamant-im/adamant-im/pull/857) — [@Linhead](https://github.com/Linhead)

--- a/src/hooks/queries/transaction/useBtcTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useBtcTransactionQuery.ts
@@ -27,7 +27,14 @@ export function useBtcTransactionQuery(
         return pendingTransaction
       }
     },
-    retry: retryFactory(Cryptos.BTC, unref(transactionId)),
+    retry: (failureCount: number): boolean => {
+      // Don't retry dust amount BTC transactions
+      const dustedIds = store.state.btc.dustedTransactionsIds || []
+      if (dustedIds.length > 0 && dustedIds.includes(unref(transactionId))) {
+        return false
+      }
+      return retryFactory(Cryptos.BTC, unref(transactionId))(failureCount)
+    },
     retryDelay: retryDelayFactory(Cryptos.BTC, unref(transactionId)),
     refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.BTC, state.status, state.data),
     refetchOnWindowFocus: false,

--- a/src/hooks/queries/transaction/useBtcTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useBtcTransactionQuery.ts
@@ -30,7 +30,7 @@ export function useBtcTransactionQuery(
     retry: (failureCount: number): boolean => {
       // Don't retry dust amount BTC transactions
       const dustedIds = store.state.btc.dustedTransactionsIds || []
-      if (dustedIds.length > 0 && dustedIds.includes(unref(transactionId))) {
+      if (dustedIds.includes(unref(transactionId))) {
         return false
       }
       return retryFactory(Cryptos.BTC, unref(transactionId))(failureCount)

--- a/src/hooks/queries/transaction/useDashTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useDashTransactionQuery.ts
@@ -30,7 +30,7 @@ export function useDashTransactionQuery(
     retry: (failureCount: number): boolean => {
       // Don't retry dust amount DASH transactions
       const dustedIds = store.state.dash.dustedTransactionsIds || []
-      if (dustedIds.length > 0 && dustedIds.includes(unref(transactionId))) {
+      if (dustedIds.includes(unref(transactionId))) {
         return false
       }
       return retryFactory(Cryptos.DASH, unref(transactionId))(failureCount)

--- a/src/hooks/queries/transaction/useDashTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useDashTransactionQuery.ts
@@ -27,7 +27,14 @@ export function useDashTransactionQuery(
         return pendingTransaction
       }
     },
-    retry: retryFactory(Cryptos.DASH, unref(transactionId)),
+    retry: (failureCount: number): boolean => {
+      // Don't retry dust amount DASH transactions
+      const dustedIds = store.state.dash.dustedTransactionsIds || []
+      if (dustedIds.length > 0 && dustedIds.includes(unref(transactionId))) {
+        return false
+      }
+      return retryFactory(Cryptos.DASH, unref(transactionId))(failureCount)
+    },
     retryDelay: retryDelayFactory(Cryptos.DASH, unref(transactionId)),
     refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.DASH, state.status, state.data),
     refetchOnWindowFocus: false,

--- a/src/hooks/queries/transaction/useDogeTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useDogeTransactionQuery.ts
@@ -27,7 +27,14 @@ export function useDogeTransactionQuery(
         return pendingTransaction
       }
     },
-    retry: retryFactory(Cryptos.DOGE, unref(transactionId)),
+    retry: (failureCount: number): boolean => {
+      // Don't retry dust amount DOGE transactions
+      const dustedIds = store.state.doge.dustedTransactionsIds || []
+      if (dustedIds.length > 0 && dustedIds.includes(unref(transactionId))) {
+        return false
+      }
+      return retryFactory(Cryptos.DOGE, unref(transactionId))(failureCount)
+    },
     retryDelay: retryDelayFactory(Cryptos.DOGE, unref(transactionId)),
     refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.DOGE, state.status, state.data),
     refetchOnWindowFocus: false,

--- a/src/hooks/queries/transaction/useDogeTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useDogeTransactionQuery.ts
@@ -30,7 +30,7 @@ export function useDogeTransactionQuery(
     retry: (failureCount: number): boolean => {
       // Don't retry dust amount DOGE transactions
       const dustedIds = store.state.doge.dustedTransactionsIds || []
-      if (dustedIds.length > 0 && dustedIds.includes(unref(transactionId))) {
+      if (dustedIds.includes(unref(transactionId))) {
         return false
       }
       return retryFactory(Cryptos.DOGE, unref(transactionId))(failureCount)

--- a/src/hooks/queries/transaction/utils.ts
+++ b/src/hooks/queries/transaction/utils.ts
@@ -15,7 +15,12 @@ import {
 export function retryFactory(crypto: CryptoSymbol, transactionId: string) {
   const txFetchInfo = getTxFetchInfo(crypto)
 
-  return (failureCount: number): boolean => {
+  return (failureCount: number, error: any): boolean => {
+    // Don't retry BTC transactions on 404 (dust amount rejections)
+    if (crypto === 'BTC' && error?.response?.status === 404) {
+      return false
+    }
+
     const pendingTransaction = PendingTxStore.get(crypto)
     const isPendingTransaction = pendingTransaction?.id === transactionId
 

--- a/src/hooks/queries/transaction/utils.ts
+++ b/src/hooks/queries/transaction/utils.ts
@@ -15,12 +15,7 @@ import {
 export function retryFactory(crypto: CryptoSymbol, transactionId: string) {
   const txFetchInfo = getTxFetchInfo(crypto)
 
-  return (failureCount: number, error: any): boolean => {
-    // Don't retry BTC transactions on 404 (dust amount rejections)
-    if (crypto === 'BTC' && error?.response?.status === 404) {
-      return false
-    }
-
+  return (failureCount: number): boolean => {
     const pendingTransaction = PendingTxStore.get(crypto)
     const isPendingTransaction = pendingTransaction?.id === transactionId
 

--- a/src/store/modules/btc-base/btc-base-actions.js
+++ b/src/store/modules/btc-base/btc-base-actions.js
@@ -231,7 +231,15 @@ function createActions(options) {
 
         return hash
       } catch (error) {
+        if (error.response && error.response.data) {
+          if (
+            ((crypto === 'BTC' || crypto === 'DOGE') && error.response.data.includes('dust')) ||
+            (crypto === 'DASH' && error.response.data.error.message.includes('dust'))
+          )
+            context.commit('dustedTransactionsIds', signedTransaction.txid)
+        }
         context.commit('transactions', [{ hash: signedTransaction.txid, status: 'REJECTED' }])
+
         PendingTxStore.remove(context.state.crypto)
         throw error
       }

--- a/src/store/modules/btc-base/btc-base-actions.js
+++ b/src/store/modules/btc-base/btc-base-actions.js
@@ -233,18 +233,6 @@ function createActions(options) {
       } catch (error) {
         context.commit('transactions', [{ hash: signedTransaction.txid, status: 'REJECTED' }])
         PendingTxStore.remove(context.state.crypto)
-
-        if (admAddress) {
-          context.commit(
-            'chat/updateMessage',
-            {
-              partnerId: admAddress,
-              id: signedTransaction.txid,
-              status: 'REJECTED'
-            },
-            { root: true }
-          )
-        }
         throw error
       }
     },

--- a/src/store/modules/btc-base/btc-base-actions.js
+++ b/src/store/modules/btc-base/btc-base-actions.js
@@ -231,15 +231,11 @@ function createActions(options) {
 
         return hash
       } catch (error) {
-if (error.response?.data?.includes?.('dust') ||
-  error.response?.data?.error?.message?.includes?.('dust')) {
-  context.commit('dustedTransactionsIds', signedTransaction.txid);
-}
-          if (
-            ((crypto === 'BTC' || crypto === 'DOGE') && error.response.data.includes('dust')) ||
-            (crypto === 'DASH' && error.response.data.error.message.includes('dust'))
-          )
-            context.commit('dustedTransactionsIds', signedTransaction.txid)
+        if (
+          error.response?.data?.includes('dust') ||
+          error.response?.data?.error?.message?.includes('dust')
+        ) {
+          context.commit('addDustedTransactionId', signedTransaction.txid)
         }
         context.commit('transactions', [{ hash: signedTransaction.txid, status: 'REJECTED' }])
 

--- a/src/store/modules/btc-base/btc-base-actions.js
+++ b/src/store/modules/btc-base/btc-base-actions.js
@@ -231,7 +231,10 @@ function createActions(options) {
 
         return hash
       } catch (error) {
-        if (error.response && error.response.data) {
+if (error.response?.data?.includes?.('dust') ||
+  error.response?.data?.error?.message?.includes?.('dust')) {
+  context.commit('dustedTransactionsIds', signedTransaction.txid);
+}
           if (
             ((crypto === 'BTC' || crypto === 'DOGE') && error.response.data.includes('dust')) ||
             (crypto === 'DASH' && error.response.data.error.message.includes('dust'))

--- a/src/store/modules/btc-base/btc-base-actions.js
+++ b/src/store/modules/btc-base/btc-base-actions.js
@@ -233,6 +233,18 @@ function createActions(options) {
       } catch (error) {
         context.commit('transactions', [{ hash: signedTransaction.txid, status: 'REJECTED' }])
         PendingTxStore.remove(context.state.crypto)
+
+        if (admAddress) {
+          context.commit(
+            'chat/updateMessage',
+            {
+              partnerId: admAddress,
+              id: signedTransaction.txid,
+              status: 'REJECTED'
+            },
+            { root: true }
+          )
+        }
         throw error
       }
     },

--- a/src/store/modules/btc-base/btc-base-mutations.js
+++ b/src/store/modules/btc-base/btc-base-mutations.js
@@ -44,7 +44,7 @@ export default (initialState) => ({
     })
   },
 
-  dustedTransactionsIds(state, dustedTransactionId) {
+  addDustedTransactionsId(state, dustedTransactionId) {
     state.dustedTransactionsIds.push(dustedTransactionId)
   },
 

--- a/src/store/modules/btc-base/btc-base-mutations.js
+++ b/src/store/modules/btc-base/btc-base-mutations.js
@@ -44,7 +44,7 @@ export default (initialState) => ({
     })
   },
 
-  addDustedTransactionsId(state, dustedTransactionId) {
+  addDustedTransactionId(state, dustedTransactionId) {
     state.dustedTransactionsIds.push(dustedTransactionId)
   },
 

--- a/src/store/modules/btc-base/btc-base-mutations.js
+++ b/src/store/modules/btc-base/btc-base-mutations.js
@@ -44,6 +44,10 @@ export default (initialState) => ({
     })
   },
 
+  dustedTransactionsIds(state, dustedTransactionId) {
+    state.dustedTransactionsIds.push(dustedTransactionId)
+  },
+
   areOlderLoading(state, areLoading) {
     state.areOlderLoading = areLoading
   },

--- a/src/store/modules/btc-base/btc-base-state.js
+++ b/src/store/modules/btc-base/btc-base-state.js
@@ -9,5 +9,6 @@ export default () => ({
   areTransactionsLoading: false,
   areRecentLoading: false,
   areOlderLoading: false,
-  bottomReached: false
+  bottomReached: false,
+  dustedTransactionsIds: []
 })


### PR DESCRIPTION
Fixes illustration of status for BTC and BTC based coins transactions which are rejected due to dust amount on chat page