### PR TITLE
fix: add removing obsolete coins that no longer exist in configs in g…

### DIFF
--- a/release-notes.md
+++ b/release-notes.md
@@ -15,6 +15,7 @@ All notable changes in this release are listed below.
 - ESLint updated to improve code quality [#849](https://github.com/Adamant-im/adamant-im/pull/849) — [@graycraft](https://github.com/graycraft)
 - Different small UI style updates [#848](https://github.com/Adamant-im/adamant-im/pull/848) — [@kalpovskii](https://github.com/kalpovskii), [@adamant-al](https://github.com/adamant-al)
 - GitHub Actions workflow and Husky postinstall git hook for ESLint [#858](https://github.com/Adamant-im/adamant-im/pull/858) — [@graycraft](https://github.com/graycraft)
+- Updated wallets generating script [#864](https://github.com/Adamant-im/adamant-im/pull/864) — [@Linhead](https://github.com/Linhead)
 
 ### Bug Fixes
 - Transaction fee calculation for ETH & ERC20 fixed [#805](https://github.com/Adamant-im/adamant-im/pull/805) — [@Linhead](https://github.com/Linhead)


### PR DESCRIPTION
### Fix: Remove obsolete cryptocurrency configs in wallets generation script

**Summary**

  - Fixed a bug where removed cryptocurrencies remained in config files after running wallets:generate
  - Added logic to clean up obsolete coin entries that no longer exist in the adamant-wallets source

  **Problem**

  The updateConfig() function in scripts/wallets.mjs only added/updated cryptocurrency configurations but never removed obsolete ones. When cryptocurrencies were removed from the adamant-wallets submodule, they would persist indefinitely in the config files (src/config/*.json), leading to:
  - Unnecessary API calls to non-existent nodes
  - Outdated configuration data

  **Solution**

  Enhanced the updateConfig() function to:
  1. Remove obsolete entries: Delete config keys that no longer exist in the source data
  2. Add/update active entries: Maintain existing functionality for current cryptocurrencies

  **Changes**

  - Added cleanup logic before updating configs in scripts/wallets.mjs:179-184
  - Fixed lodash import to use default import (import _ from 'lodash') for consistency