### PR TITLE
fix: fix status and visibillity dust amount rejected transactions on

### DIFF
--- a/src/store/modules/btc-base/btc-base-actions.js
+++ b/src/store/modules/btc-base/btc-base-actions.js
@@ -10,6 +10,7 @@ import {
 } from '@/lib/pending-transactions'
 import { storeCryptoAddress, validateStoredCryptoAddresses } from '@/lib/store-crypto-address'
 import shouldUpdate from '@/store/utils/coinUpdatesGuard'
+import { useFinalTransactions } from '@/stores/final-transactions'
 
 const DEFAULT_CUSTOM_ACTIONS = () => ({})
 let interval
@@ -223,7 +224,16 @@ function createActions(options) {
 
         return hash
       } catch (error) {
-        context.commit('transactions', [{ hash: signedTransaction.txid, status: 'REJECTED' }])
+        const transactionData = { hash: signedTransaction.txid, status: 'REJECTED' }
+        if (
+          error.response?.data?.includes?.('dust') ||
+          error.response?.data?.error?.message?.includes?.('dust')
+        ) {
+          transactionData.isDust = true
+        }
+        context.commit('transactions', [transactionData])
+        const { addTransaction } = useFinalTransactions()
+        addTransaction(signedTransaction.txid, 'REJECTED')
         PendingTxStore.remove(context.state.crypto)
         throw error
       }

--- a/src/views/Transactions.vue
+++ b/src/views/Transactions.vue
@@ -85,7 +85,7 @@ const isOlderLoading = computed(() => store.getters[`${cryptoModule.value}/areOl
 const isLoginViaPassword = computed(() => store.getters['options/isLoginViaPassword'])
 const isIDBReady = computed(() => store.state.IDBReady)
 const transactions = computed(() => {
-  const transactions: (CoinTransaction & { data?: string })[] =
+  const transactions: (CoinTransaction & { data?: string; isDust: boolean })[] =
     store.getters[`${cryptoModule.value}/sortedTransactions`]
 
   const address = store.state[props.crypto.toLowerCase()].address
@@ -93,7 +93,8 @@ const transactions = computed(() => {
     // Filter invalid "fake" transactions (from chat rich message)
     return (
       Object.prototype.hasOwnProperty.call(tx, 'amount') &&
-      (isStringEqualCI(tx.recipientId, address) || isStringEqualCI(tx.senderId, address))
+      (isStringEqualCI(tx.recipientId, address) || isStringEqualCI(tx.senderId, address)) &&
+      !tx.isDust
     )
   })
 })


### PR DESCRIPTION
### Fix status and visibillity dust amount rejected transactions on on chat, chat-preview and transactions pages

## Description
Fixed dust amount rejection handling for BTC-based transactions. The fix properly detects dust rejection errors from server response and marks transactions with isDust flag, then filters them out from transaction views to prevent display of rejected dust transactions on transactions on page and immediately displays it with correct status on chat and preview chat pages
