### PR TITLE
fix: correct scroll position when closing keyboard on mobile

### DIFF
--- a/src/components/AChat/AChat.vue
+++ b/src/components/AChat/AChat.vue
@@ -124,7 +124,7 @@ const resizeHandler = () => {
     Math.ceil(messagesRef.value.scrollTop)
   const scrolledToBottom = nonVisibleClientHeight === 0
 
-  if (!scrolledToBottom) {
+  if (!scrolledToBottom && clientHeightDelta > 0) {
     messagesRef.value.scrollTop += clientHeightDelta
   }
 


### PR DESCRIPTION
## Description

Fixed incorrect scroll position adjustment in chat when closing mobile keyboard. The `resizeHandler` in `AChat.vue` was applying scroll correction regardless of viewport resize direction, causing the chat to scroll up ~4-5 messages when keyboard closes.

**Changes:**
- Added condition `clientHeightDelta > 0` to only adjust scroll when viewport shrinks (keyboard opens)
- Preserved scroll position when viewport expands (keyboard closes)
- Single-line change following Open-Closed principle for minimal regression risk

## Related issue

Closes [#886 ](url)

## Breaking changes

No

## How to test

### Prerequisites
- Test on older Android device (Samsung A10/A11/A12/A13) or device with Chrome WebView < 108
- Or use BrowserStack/similar service for older Android versions

### Test Steps

**Test Case 1: Basic keyboard close**
1. Open any chat dialog with 10+ messages
2. Tap message input field to open keyboard
3. Send 5 short text messages (e.g., "test 1", "test 2", etc.)
4. Close keyboard by tapping on message area

**Expected:** Last sent message ("test 5") is visible at bottom  
**Actual before fix:** Last message is hidden, need to scroll down manually

**Test Case 2: Scrolling with keyboard open**
1. Open chat with 20+ messages
2. Tap input field to open keyboard
3. Scroll up to read older messages
4. Close keyboard

**Expected:** Scroll position preserved at the same messages  
**Actual before fix:** Scroll jumps up further, hiding more messages

**Test Case 3: Rapid message sending**
1. Open chat dialog
2. Tap input field
3. Rapidly send 10 messages without closing keyboard
4. Close keyboard

**Expected:** Last message visible  
**Actual before fix:** Last ~4 messages hidden
## Notes for reviewers

Highlight anything important that reviewers should pay attention to.  
(e.g. tricky logic, potential side effects, performance considerations)

## Checklist

- [x] Code is formatted
- [ ] Tests added/updated (if needed) - no need
- [ ] Documentation updated (if needed) - no need
- [ ] Changes tested in all relevant environments - I could not reproduce it on my device
