### PR TITLE
fix: prevent markup overflow in Chat when replying to messages with long links

### DIFF
--- a/src/views/Chat.vue
+++ b/src/views/Chat.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row justify="center" no-gutters>
+  <v-row justify="center" no-gutters class="w-100">
     <container>
       <chat
         :key="partnerId"


### PR DESCRIPTION
## Description

Fixed markup overflow in Chat view when replying to messages containing long URLs on narrow screens.

Added `w-100` utility class to the root `v-row` element in `Chat.vue` to ensure it takes the full width of its flex container. This allows the inner `Container` component to properly constrain and handle text overflow, preventing layout breaking when long links are present in replied messages.

## Related issue

Closes [#891](https://github.com/Adamant-im/adamant-im/issues/891)

## External links (optional)

N/A

## Screenshots or videos (optional)

N/A

## Breaking changes

No breaking changes.

## How to test

1. Set browser window to a narrow width (e.g., mobile viewport)
2. Send a message with a long URL like: `https://docs.google.com/spreadsheets/d/14wgjZOpFastrLq04hb71BgRgsdfgfC1JMPiOlHDMiJfsdfgsd0y0EqyH4I/edit?usp=sharing`
3. Reply to that message
4. Verify that the markup doesn't overflow and remains properly contained within the chat area
5. Test with different screen widths to ensure responsive behavior is maintained

## Notes for reviewers

- The change is minimal (single class addition) and follows existing patterns in the codebase
- `w-100` class is already used in similar view components (`Wallets.vue`, `Votes.vue`)
- The fix is specific to the Chat view's flex layout within `AppSidebar`
- No impact on other views as this is an isolated component change

## Checklist

- [x] Code is formatted
- [ ] Tests added/updated (if needed) — N/A for UI fix
- [ ] Documentation updated (if needed) — N/A
- [x] Changes tested in all relevant environments
