### PR TITLE
chore: add showing readble message without stack trace to nodes offline and nodes disabled errors

### DIFF
--- a/src/lib/nodes/utils/errors.ts
+++ b/src/lib/nodes/utils/errors.ts
@@ -42,6 +42,8 @@ export class AllNodesOfflineError extends Error {
     super(`${label}: All nodes are offline`)
 
     this.nodeLabel = label
+    // Override stack to show only the message without stack trace in console
+    this.stack = this.message
   }
 }
 
@@ -57,6 +59,8 @@ export class AllNodesDisabledError extends Error {
     super(`${label}: All nodes are disabled`)
 
     this.nodeLabel = label
+    // Override stack to show only the message without stack trace in console
+    this.stack = this.message
   }
 }
 
@@ -66,6 +70,6 @@ export function isAllNodesDisabledError(error: Error): error is AllNodesDisabled
 
 export class NoInternetConnectionError extends Error {
   constructor() {
-    super();
+    super()
   }
 }


### PR DESCRIPTION
## Description

Fixed console output for expected node errors (`AllNodesOfflineError` and `AllNodesDisabledError`). When all cryptocurrency nodes are disabled or offline, the browser console now displays a clean, readable message instead of cluttering it with full error stack traces.

## Related issue

Closes [#902 ](https://github.com/Adamant-im/adamant-im/issues/902)

## External links (optional)

N/A

## Screenshots or videos (optional)

N/A

## Breaking changes

No breaking changes. This only affects console output formatting for specific error types.

## How to test

1. Open the application in a browser with DevTools console open
2. Go to Settings → Nodes
3. Disable all nodes for any cryptocurrency (e.g., DASH, BTC, ETH)
4. Navigate to chat list or a specific chat
5. **Expected result:** Console shows only clean messages like `dash: All nodes are disabled` without stack traces

## Notes for reviewers

- This is a simple, focused change affecting only error display
- The `stack` property override is a standard JavaScript pattern for customizing error output
- Only affects `AllNodesOfflineError` and `AllNodesDisabledError` - all other errors remain unchanged
- The actual Error object remains intact with all properties; only console display is affected

## Checklist

- [x] Code is formatted
- [ ] Tests added/updated (not needed)
- [ ] Documentation updated (not needed)
- [ ] Changes tested in all relevant environments
