### PR TITLE
Fix: sync Android version metadata automation into dev

### DIFF
--- a/.github/workflows/capacitor-android.yml
+++ b/.github/workflows/capacitor-android.yml
@@ -70,7 +70,7 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           SRC="android/app/build/outputs/apk/release/app-release-signed.apk"
           DEST="android/app/build/outputs/apk/release/ADAMANT.Messenger-${VERSION}-signed.apk"
-          mv "$SRC" "$DEST"    
+          mv "$SRC" "$DEST"
 
       - name: Build and Sign Android App (AAB) 🛠️
         run: |
@@ -81,6 +81,13 @@ jobs:
             --keystorealias $ANDROID_KEYSTORE_ALIAS \
             --keystorealiaspass $ANDROID_KEYSTORE_ALIAS_PASSWORD \
             --androidreleasetype AAB
+
+      - name: Rename AAB with version from package.json
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          SRC="android/app/build/outputs/bundle/release/app-release-signed.aab"
+          DEST="android/app/build/outputs/bundle/release/ADAMANT.Messenger-${VERSION}-signed.aab"
+          mv "$SRC" "$DEST"
 
       - name: Save artifacts 💾
         uses: actions/upload-artifact@v4

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -1,3 +1,29 @@
+import groovy.json.JsonSlurper
+
+def packageJsonFile = rootProject.file('../package.json')
+
+if (!packageJsonFile.exists()) {
+    throw new GradleException("package.json was not found at ${packageJsonFile}")
+}
+
+def packageJson = new JsonSlurper().parseText(packageJsonFile.text)
+def androidVersionName = packageJson.version?.toString()
+
+if (!androidVersionName) {
+    throw new GradleException('package.json does not contain a valid version field')
+}
+
+def versionMatcher = (androidVersionName =~ /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/)
+
+if (!versionMatcher.matches()) {
+    throw new GradleException("Unsupported package.json version format: ${androidVersionName}")
+}
+
+def versionParts = versionMatcher[0][1..3].collect { it as Integer }
+
+// Reserve two digits for minor and patch to keep versionCode monotonic for Google Play
+def androidVersionCode = (versionParts[0] * 10000) + (versionParts[1] * 100) + versionParts[2]
+
 apply plugin: 'com.android.application'
 
 android {
@@ -7,8 +33,8 @@ android {
         applicationId "im.adamant.adamantmessengerpwa"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
-        versionCode 4106
-        versionName "4.10.6"
+        versionCode androidVersionCode
+        versionName androidVersionName
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         aaptOptions {
              // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.


### PR DESCRIPTION
## Description

Sync the Android version metadata automation fix from `master` into `dev`.

This keeps Android `versionName` and `versionCode` aligned with `package.json` and renames the signed AAB artifact to the package version.

## Related issue

Closes #945

## How to test

1. Run Android workflow on `dev`
2. Download `android-release-app`
3. Confirm `apk/release/output-metadata.json` reports `versionName: 4.11.0` and `versionCode: 41100`
4. Confirm the artifact includes `bundle/release/ADAMANT.Messenger-4.11.0-signed.aab`

## Checklist

- [x] Issue linked
- [x] Scope is limited to Android version metadata and artifact naming
- [x] Master workflow verification referenced
- [ ] Manual validation on `dev` after merge
