### PR TITLE
Fix: stabilize send funds and crypto transfer status handling

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,7 @@ const outputDir = path.join(runRootDir, 'artifacts')
 
 export default defineConfig({
   testDir: './tests/e2e',
-  timeout: 90_000,
+  timeout: 120_000,
   expect: {
     timeout: 15_000
   },

--- a/src/components/AChat/AChatAttachment/AChatAttachment.vue
+++ b/src/components/AChat/AChatAttachment/AChatAttachment.vue
@@ -106,6 +106,7 @@ import { FileAsset } from '@/lib/adamant-api/asset'
 import { ref, computed, defineComponent, PropType } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
+import { mdiCheck } from '@mdi/js'
 
 import { useFormatMessage } from '../hooks/useFormatMessage'
 import { usePartnerId } from '../hooks/usePartnerId'
@@ -113,7 +114,7 @@ import { useTransactionTime } from '../hooks/useTransactionTime'
 import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
 import { isLocalFile } from '@/lib/files'
 import { downloadFile, isStringEqualCI } from '@/lib/textHelpers'
-import { tsIcon } from '@/lib/constants'
+import { TransactionStatus, tsIcon } from '@/lib/constants'
 import QuotedMessage from '../QuotedMessage.vue'
 import { useSwipeLeft } from '@/hooks/useSwipeLeft'
 import formatDate from '@/filters/date'
@@ -184,7 +185,11 @@ export default defineComponent({
     }
     const showAvatar = computed(() => !isWelcomeChat(partnerId.value))
 
-    const statusIcon = computed(() => tsIcon(props.transaction.status))
+    const statusIcon = computed(() =>
+      props.transaction.status === TransactionStatus.REGISTERED
+        ? mdiCheck
+        : tsIcon(props.transaction.status)
+    )
     const isOutgoingMessage = computed(() =>
       isStringEqualCI(props.transaction.senderId, userId.value)
     )

--- a/src/components/AChat/AChatAttachment/AChatImageModal.vue
+++ b/src/components/AChat/AChatAttachment/AChatImageModal.vue
@@ -1,12 +1,5 @@
 <template>
-  <v-dialog
-    v-model="show"
-    fullscreen
-    scrim
-    :class="classes.root"
-    @keydown="handleKeydown"
-    @click:outside="closeModal"
-  >
+  <v-dialog v-model="show" fullscreen scrim :class="classes.root" @keydown="handleKeydown">
     <v-card :class="classes.container">
       <div :class="classes.content" @click.capture="handleBackgroundClick">
         <v-toolbar color="transparent">

--- a/src/components/AChat/AChatAttachment/AChatImageModal.vue
+++ b/src/components/AChat/AChatAttachment/AChatImageModal.vue
@@ -1,5 +1,12 @@
 <template>
-  <v-dialog v-model="show" fullscreen scrim :class="classes.root" @keydown="handleKeydown">
+  <v-dialog
+    v-model="show"
+    fullscreen
+    scrim
+    :class="classes.root"
+    @keydown="handleKeydown"
+    @click:outside="closeModal"
+  >
     <v-card :class="classes.container">
       <div :class="classes.content" @click.capture="handleBackgroundClick">
         <v-toolbar color="transparent">

--- a/src/components/AChat/AChatMessage.vue
+++ b/src/components/AChat/AChatMessage.vue
@@ -90,6 +90,7 @@
 import { computed, defineComponent, onBeforeUnmount, PropType, ref, watch } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useStore } from 'vuex'
+import { mdiCheck } from '@mdi/js'
 
 import { useFormatMessage } from './hooks/useFormatMessage'
 import { usePartnerId } from './hooks/usePartnerId'
@@ -151,7 +152,11 @@ export default defineComponent({
 
     const showAvatar = computed(() => !isWelcomeChat(partnerId.value))
 
-    const statusIcon = computed(() => tsIcon(props.transaction.status))
+    const statusIcon = computed(() =>
+      props.transaction.status === TransactionStatus.REGISTERED
+        ? mdiCheck
+        : tsIcon(props.transaction.status)
+    )
     const isOutgoingMessage = computed(() =>
       isStringEqualCI(props.transaction.senderId, userId.value)
     )

--- a/src/components/AChat/__tests__/AChatMessageStatuses.test.ts
+++ b/src/components/AChat/__tests__/AChatMessageStatuses.test.ts
@@ -3,6 +3,7 @@ import { mount } from '@vue/test-utils'
 import { createStore } from 'vuex'
 import { createI18n } from 'vue-i18n'
 import { defineComponent, nextTick } from 'vue'
+import { mdiCheck, mdiClockCheckOutline } from '@mdi/js'
 
 import AChatMessage from '../AChatMessage.vue'
 import AChatAttachment from '../AChatAttachment/AChatAttachment.vue'
@@ -442,5 +443,24 @@ describe('AChat sending status UI', () => {
     expect(wrapper.find('.a-chat__message-card-header').exists()).toBe(true)
     expect(wrapper.find('.a-chat__timestamp').exists()).toBe(true)
     expect(wrapper.find('.a-chat__status .v-icon').exists()).toBe(true)
+  })
+
+  it('renders registered outgoing text messages with a plain check icon', () => {
+    const store = createTestStore()
+    const wrapper = mount(AChatMessage, {
+      props: {
+        transaction: createTextTransaction({
+          showTime: true,
+          showBubble: true,
+          status: TransactionStatus.REGISTERED
+        })
+      },
+      global: globalMountOptions(store)
+    })
+
+    expect(wrapper.find('.a-chat__status .v-icon').attributes('data-icon')).toBe(mdiCheck)
+    expect(wrapper.find('.a-chat__status .v-icon').attributes('data-icon')).not.toBe(
+      mdiClockCheckOutline
+    )
   })
 })

--- a/src/components/AChat/__tests__/AChatMessageStatuses.test.ts
+++ b/src/components/AChat/__tests__/AChatMessageStatuses.test.ts
@@ -8,7 +8,7 @@ import { mdiCheck, mdiClockCheckOutline } from '@mdi/js'
 import AChatMessage from '../AChatMessage.vue'
 import AChatAttachment from '../AChatAttachment/AChatAttachment.vue'
 import AChatTransaction from '../AChatTransaction.vue'
-import { TransactionStatus } from '@/lib/constants'
+import { TransactionStatus, tsColor } from '@/lib/constants'
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 ;(globalThis as any).config = new Proxy(
@@ -177,7 +177,9 @@ const i18n = createI18n({
         transaction_statuses: {
           PENDING: 'Pending',
           REGISTERED: 'Registered',
-          REJECTED: 'Rejected'
+          CONFIRMED: 'Confirmed',
+          REJECTED: 'Rejected',
+          INVALID: 'Invalid'
         }
       }
     }
@@ -443,6 +445,45 @@ describe('AChat sending status UI', () => {
     expect(wrapper.find('.a-chat__message-card-header').exists()).toBe(true)
     expect(wrapper.find('.a-chat__timestamp').exists()).toBe(true)
     expect(wrapper.find('.a-chat__status .v-icon').exists()).toBe(true)
+  })
+
+  it('colors confirmed, rejected and invalid crypto transfer statuses in chat bubbles', () => {
+    const store = createTestStore()
+
+    const confirmedWrapper = mount(AChatTransaction, {
+      props: {
+        transaction: createCryptoTransaction({
+          status: TransactionStatus.CONFIRMED
+        })
+      },
+      global: globalMountOptions(store)
+    })
+    const rejectedWrapper = mount(AChatTransaction, {
+      props: {
+        transaction: createCryptoTransaction({
+          status: TransactionStatus.REJECTED
+        })
+      },
+      global: globalMountOptions(store)
+    })
+    const invalidWrapper = mount(AChatTransaction, {
+      props: {
+        transaction: createCryptoTransaction({
+          status: TransactionStatus.INVALID
+        })
+      },
+      global: globalMountOptions(store)
+    })
+
+    expect(confirmedWrapper.find('.a-chat__status .v-icon').attributes('data-color')).toBe(
+      tsColor(TransactionStatus.CONFIRMED)
+    )
+    expect(rejectedWrapper.find('.a-chat__status .v-icon').attributes('data-color')).toBe(
+      tsColor(TransactionStatus.REJECTED)
+    )
+    expect(invalidWrapper.find('.a-chat__status .v-icon').attributes('data-color')).toBe(
+      tsColor(TransactionStatus.INVALID)
+    )
   })
 
   it('renders registered outgoing text messages with a plain check icon', () => {

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -57,7 +57,7 @@
                 :icon="tsIcon(status)"
                 :class="`${className}__status-icon`"
               />
-              {{ transactionDirection }} {{ currency(transaction.amount, transaction.type) }}
+              <span>{{ transactionPreviewText }}</span>
               <v-icon
                 v-if="isIncomingTransaction"
                 :size="CHAT_PREVIEW_STATUS_ICON_SIZE"
@@ -123,7 +123,7 @@ import { isStringEqualCI } from '@/lib/textHelpers'
 import { tsIcon, TransactionStatus as TS } from '@/lib/constants'
 import { useChatName } from '@/components/AChat/hooks/useChatName'
 import { TransactionProvider } from '@/providers/TransactionProvider'
-import { mdiArrowLeftTop, mdiDotsHorizontal } from '@mdi/js'
+import { mdiArrowLeftTop, mdiCheck, mdiDotsHorizontal } from '@mdi/js'
 import { AdamantChatMeta } from '@/lib/chat/meta/chat-meta'
 
 const className = 'chat-brief'
@@ -217,6 +217,10 @@ const transactionDirection = computed(() => {
 
   return direction
 })
+const transactionPreviewText = computed(
+  () =>
+    `${transactionDirection.value} ${currency(props.transaction.amount, props.transaction.type)}`
+)
 const isIncomingTransaction = computed(
   () => !isStringEqualCI(props.userId, props.transaction.senderId)
 )
@@ -225,7 +229,9 @@ const numOfNewMessages = computed(() => store.getters['chat/numOfNewMessages'](c
 const createdAt = computed(() => props.transaction.timestamp)
 
 const status = computed(() => props.transaction.status)
-const admStatusIcon = computed(() => tsIcon(status.value))
+const admStatusIcon = computed(() =>
+  status.value === TS.REGISTERED ? mdiCheck : tsIcon(status.value)
+)
 const isConfirmed = computed(() => status.value === TS.CONFIRMED)
 </script>
 

--- a/src/components/ChatPreview.vue
+++ b/src/components/ChatPreview.vue
@@ -55,6 +55,7 @@
                 v-if="!isIncomingTransaction"
                 :size="CHAT_PREVIEW_STATUS_ICON_SIZE"
                 :icon="tsIcon(status)"
+                :color="tsColor(status)"
                 :class="`${className}__status-icon`"
               />
               <span>{{ transactionPreviewText }}</span>
@@ -62,6 +63,7 @@
                 v-if="isIncomingTransaction"
                 :size="CHAT_PREVIEW_STATUS_ICON_SIZE"
                 :icon="tsIcon(status)"
+                :color="tsColor(status)"
                 :class="`${className}__status-icon`"
               />
             </v-list-item-subtitle>
@@ -120,7 +122,7 @@ import { formatChatPreviewMessage } from '@/lib/markdown'
 import { isAdamantChat, isWelcomeChat } from '@/lib/chat/meta/utils'
 import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
 import { isStringEqualCI } from '@/lib/textHelpers'
-import { tsIcon, TransactionStatus as TS } from '@/lib/constants'
+import { tsColor, tsIcon, TransactionStatus as TS } from '@/lib/constants'
 import { useChatName } from '@/components/AChat/hooks/useChatName'
 import { TransactionProvider } from '@/providers/TransactionProvider'
 import { mdiArrowLeftTop, mdiCheck, mdiDotsHorizontal } from '@mdi/js'

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -77,6 +77,7 @@ import { timestampInSec } from '@/filters/helpers'
 import currency from '@/filters/currencyAmountWithSymbol'
 import { mdiAirplaneLanding, mdiAirplaneTakeoff, mdiMessageOutline, mdiMessageText } from '@mdi/js'
 import { useTransactionQuery } from '@/hooks/queries/transaction'
+import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from '@/components/transactions/hooks/useTransactionStatus'
 import { useClearPendingTransaction } from '@/components/transactions/hooks/useClearPendingTransaction'
 
@@ -133,10 +134,16 @@ export default {
       enabled: hasLiveStatusTracking
     })
     const liveTransactionStatus = computed(() => liveTransaction.value?.status)
+    const liveAdditionalStatus = useTransactionAdditionalStatus(
+      liveTransaction,
+      toRef(props, 'crypto')
+    )
     const liveStatus = useTransactionStatus(
       isLiveTransactionFetching,
       liveQueryStatus,
-      liveTransactionStatus
+      liveTransactionStatus,
+      undefined,
+      liveAdditionalStatus
     )
 
     useClearPendingTransaction(toRef(props, 'crypto'), liveTransaction, liveStatus)
@@ -299,7 +306,7 @@ export default {
         )
       }
 
-      // If crytpo is not ADM: we have to scan all the messages
+      // If crypto is not ADM: we have to scan all the messages
       const admTx = {}
       Object.values(this.$store.state.chat.chats).some((chat) => {
         Object.values(chat.messages).some((msg) => {

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -4,7 +4,9 @@
       <template #prepend>
         <v-icon
           :class="`${className}__prepend-icon ${directionClass}`"
-          :icon="isStringEqualCI(senderId, userId) ? mdiAirplaneTakeoff : mdiAirplaneLanding"
+          :icon="
+            isStringEqualCI(resolvedSenderId, userId) ? mdiAirplaneTakeoff : mdiAirplaneLanding
+          "
           size="small"
         />
       </template>
@@ -19,7 +21,7 @@
 
       <v-list-item-title>
         <span :class="`${className}__amount ${directionClass}`">{{
-          currency(amount, crypto)
+          currency(resolvedAmount, crypto)
         }}</span>
         <span :class="`${className}__rates`">{{ historyRate }}</span>
         <span
@@ -40,9 +42,11 @@
 
       <v-list-item-subtitle :class="`${className}__date`">
         <span v-if="!isStatusVisibleTransaction">{{ formatDate(createdAt) }}</span>
-        <span v-else-if="status" :class="`${className}__status ${className}__status--${status}`">{{
-          $t(`transaction.statuses.${status}`)
-        }}</span>
+        <span
+          v-else-if="resolvedStatus"
+          :class="`${className}__status ${className}__status--${resolvedStatus}`"
+          >{{ $t(`transaction.statuses.${resolvedStatus}`) }}</span
+        >
       </v-list-item-subtitle>
 
       <template #append>
@@ -63,6 +67,7 @@
 </template>
 
 <script>
+import { computed, toRef } from 'vue'
 import formatDate from '@/filters/date'
 import { EPOCH, Cryptos, TransactionStatus } from '@/lib/constants'
 import partnerName from '@/mixins/partnerName'
@@ -71,6 +76,9 @@ import currencyAmount from '@/filters/currencyAmount'
 import { timestampInSec } from '@/filters/helpers'
 import currency from '@/filters/currencyAmountWithSymbol'
 import { mdiAirplaneLanding, mdiAirplaneTakeoff, mdiMessageOutline, mdiMessageText } from '@mdi/js'
+import { useTransactionQuery } from '@/hooks/queries/transaction'
+import { useTransactionStatus } from '@/components/transactions/hooks/useTransactionStatus'
+import { useClearPendingTransaction } from '@/components/transactions/hooks/useClearPendingTransaction'
 
 export default {
   mixins: [partnerName],
@@ -111,8 +119,32 @@ export default {
     }
   },
   emits: ['click:transaction', 'click:icon'],
-  setup() {
+  setup(props) {
+    const hasLiveStatusTracking = computed(() => {
+      return (
+        props.status === TransactionStatus.PENDING || props.status === TransactionStatus.REGISTERED
+      )
+    })
+    const {
+      data: liveTransaction,
+      status: liveQueryStatus,
+      isFetching: isLiveTransactionFetching
+    } = useTransactionQuery(toRef(props, 'id'), props.crypto, {
+      enabled: hasLiveStatusTracking
+    })
+    const liveTransactionStatus = computed(() => liveTransaction.value?.status)
+    const liveStatus = useTransactionStatus(
+      isLiveTransactionFetching,
+      liveQueryStatus,
+      liveTransactionStatus
+    )
+
+    useClearPendingTransaction(toRef(props, 'crypto'), liveTransaction, liveStatus)
+
     return {
+      hasLiveStatusTracking,
+      liveStatus,
+      liveTransaction,
       mdiAirplaneLanding,
       mdiAirplaneTakeoff,
       mdiMessageOutline,
@@ -122,7 +154,29 @@ export default {
   data: () => ({
     virtualTimestamp: Date.now()
   }),
+  watch: {
+    resolvedTimestamp() {
+      this.getHistoryRates()
+    }
+  },
   computed: {
+    resolvedSenderId() {
+      return this.liveTransaction?.senderId || this.senderId
+    },
+    resolvedRecipientId() {
+      return this.liveTransaction?.recipientId || this.recipientId
+    },
+    resolvedAmount() {
+      return this.liveTransaction?.amount ?? this.amount
+    },
+    resolvedStatus() {
+      return this.hasLiveStatusTracking ? this.liveStatus : this.status
+    },
+    resolvedTimestamp() {
+      return typeof this.liveTransaction?.timestamp === 'number'
+        ? this.liveTransaction.timestamp
+        : this.timestamp
+    },
     // Own crypto address, like 1F9bMGsui6GbcFaGSNao5YcjnEk38eXXg7 or U3716604363012166999
     userId() {
       if (this.crypto === Cryptos.ADM) {
@@ -134,7 +188,9 @@ export default {
     },
     // Crypto address, like 1F9bMGsui6GbcFaGSNao5YcjnEk38eXXg7 or U3716604363012166999
     partnerId() {
-      return isStringEqualCI(this.senderId, this.userId) ? this.recipientId : this.senderId
+      return isStringEqualCI(this.resolvedSenderId, this.userId)
+        ? this.resolvedRecipientId
+        : this.resolvedSenderId
     },
     // Partner's ADM address, if found. Else, returns 'undefined'
     partnerAdmId() {
@@ -157,9 +213,9 @@ export default {
     },
     createdAt() {
       if (this.crypto === 'ADM') {
-        return this.timestamp * 1000 + EPOCH
+        return this.resolvedTimestamp * 1000 + EPOCH
       }
-      return this.timestamp
+      return this.resolvedTimestamp
     },
     isPartnerInChatList() {
       return this.$store.getters['chat/isPartnerInChatList'](this.partnerAdmId)
@@ -176,11 +232,11 @@ export default {
     },
     directionClass() {
       if (
-        isStringEqualCI(this.senderId, this.userId) &&
-        isStringEqualCI(this.recipientId, this.userId)
+        isStringEqualCI(this.resolvedSenderId, this.userId) &&
+        isStringEqualCI(this.resolvedRecipientId, this.userId)
       ) {
         return `${this.className}__amount--is-itself`
-      } else if (isStringEqualCI(this.senderId, this.userId)) {
+      } else if (isStringEqualCI(this.resolvedSenderId, this.userId)) {
         return `${this.className}__amount--is-outgoing`
       } else {
         return `${this.className}__amount--is-incoming`
@@ -191,11 +247,11 @@ export default {
       return admTx.message
     },
     historyRate() {
-      const amount = currencyAmount(this.amount, this.crypto)
+      const amount = currencyAmount(this.resolvedAmount, this.crypto)
       return (
         '~' +
         this.$store.getters['rate/historyRate'](
-          timestampInSec(this.crypto, this.timestamp || this.virtualTimestamp),
+          timestampInSec(this.crypto, this.resolvedTimestamp || this.virtualTimestamp),
           amount,
           this.crypto
         )
@@ -203,9 +259,9 @@ export default {
     },
     isStatusVisibleTransaction() {
       return (
-        this.status === TransactionStatus.PENDING ||
-        this.status === TransactionStatus.REGISTERED ||
-        this.status === TransactionStatus.REJECTED
+        this.resolvedStatus === TransactionStatus.PENDING ||
+        this.resolvedStatus === TransactionStatus.REGISTERED ||
+        this.resolvedStatus === TransactionStatus.REJECTED
       )
     }
   },
@@ -258,7 +314,7 @@ export default {
     },
     getHistoryRates() {
       this.$store.dispatch('rate/getHistoryRates', {
-        timestamp: timestampInSec(this.crypto, this.timestamp || this.virtualTimestamp)
+        timestamp: timestampInSec(this.crypto, this.resolvedTimestamp || this.virtualTimestamp)
       })
     },
     currency,

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -146,6 +146,7 @@ export default {
       liveQueryStatus,
       liveTransactionStatus,
       undefined,
+      undefined,
       liveAdditionalStatus,
       isLiveTransactionLoadingError,
       isLiveTransactionRefetchError,

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -21,7 +21,7 @@
 
       <v-list-item-title>
         <span :class="`${className}__amount ${directionClass}`">{{
-          currency(resolvedAmount, crypto)
+          currency(resolvedAmount, crypto, isAdmLiveAmountNormalized)
         }}</span>
         <span :class="`${className}__rates`">{{ historyRate }}</span>
         <span
@@ -182,6 +182,9 @@ export default {
     resolvedAmount() {
       return this.liveTransaction?.amount ?? this.amount
     },
+    isAdmLiveAmountNormalized() {
+      return this.crypto === Cryptos.ADM && typeof this.liveTransaction?.amount === 'number'
+    },
     resolvedStatus() {
       return this.hasLiveStatusTracking ? this.liveStatus : this.status
     },
@@ -208,9 +211,24 @@ export default {
     // Partner's ADM address, if found. Else, returns 'undefined'
     partnerAdmId() {
       const admTx = this.getAdmTx
-      return isStringEqualCI(admTx.senderId, this.$store.state.address)
-        ? admTx.recipientId
-        : admTx.senderId
+      if (admTx.senderId || admTx.recipientId) {
+        return isStringEqualCI(admTx.senderId, this.$store.state.address)
+          ? admTx.recipientId
+          : admTx.senderId
+      }
+
+      if (this.isCryptoADM()) {
+        return this.partnerId
+      }
+
+      const partners = this.$store.state.partners?.list || {}
+      const cryptoKey = this.crypto
+
+      return (
+        Object.keys(partners).find((uid) =>
+          isStringEqualCI(partners[uid]?.[cryptoKey], this.partnerId)
+        ) || ''
+      )
     },
     // Partner's name from KVS, if partnerAdmId found
     partnerName() {
@@ -260,7 +278,11 @@ export default {
       return admTx.message
     },
     historyRate() {
-      const amount = currencyAmount(this.resolvedAmount, this.crypto)
+      const amount = currencyAmount(
+        this.resolvedAmount,
+        this.crypto,
+        this.isAdmLiveAmountNormalized
+      )
       return (
         '~' +
         this.$store.getters['rate/historyRate'](

--- a/src/components/TransactionListItem.vue
+++ b/src/components/TransactionListItem.vue
@@ -129,7 +129,10 @@ export default {
     const {
       data: liveTransaction,
       status: liveQueryStatus,
-      isFetching: isLiveTransactionFetching
+      isFetching: isLiveTransactionFetching,
+      isLoadingError: isLiveTransactionLoadingError,
+      isRefetchError: isLiveTransactionRefetchError,
+      error: liveTransactionError
     } = useTransactionQuery(toRef(props, 'id'), props.crypto, {
       enabled: hasLiveStatusTracking
     })
@@ -143,7 +146,10 @@ export default {
       liveQueryStatus,
       liveTransactionStatus,
       undefined,
-      liveAdditionalStatus
+      liveAdditionalStatus,
+      isLiveTransactionLoadingError,
+      isLiveTransactionRefetchError,
+      liveTransactionError
     )
 
     useClearPendingTransaction(toRef(props, 'crypto'), liveTransaction, liveStatus)

--- a/src/components/__tests__/ChatPreview.status-colors.test.ts
+++ b/src/components/__tests__/ChatPreview.status-colors.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { createI18n } from 'vue-i18n'
+import { defineComponent } from 'vue'
+import { TransactionStatus, tsColor } from '@/lib/constants'
+import ChatPreview from '@/components/ChatPreview.vue'
+
+vi.mock('@/components/Chat/ChatAvatar.vue', () => ({
+  default: defineComponent({
+    name: 'ChatAvatar',
+    template: '<div class="chat-avatar-stub" />'
+  })
+}))
+
+vi.mock('@/components/icons/AdmFill.vue', () => ({
+  default: defineComponent({
+    name: 'AdmFillIcon',
+    template: '<div class="adm-fill-icon-stub" />'
+  })
+}))
+
+vi.mock('@/components/icons/BaseIcon.vue', () => ({
+  default: defineComponent({
+    name: 'BaseIcon',
+    template: '<div class="base-icon-stub"><slot /></div>'
+  })
+}))
+
+vi.mock('@/components/AChat/hooks/useChatName', () => ({
+  useChatName: () => 'Test chat'
+}))
+
+vi.mock('@/lib/chat/meta/utils', () => ({
+  isAdamantChat: () => false,
+  isWelcomeChat: () => false
+}))
+
+vi.mock('@/filters/currencyAmountWithSymbol', () => ({
+  default: (amount: number, symbol: string) => `${amount} ${symbol}`
+}))
+
+vi.mock('@/filters/dateBrief', () => ({
+  default: () => 'May 15'
+}))
+
+vi.mock('@/lib/markdown', () => ({
+  formatChatPreviewMessage: (text: string) => text
+}))
+
+vi.mock('@/providers/TransactionProvider', () => ({
+  TransactionProvider: defineComponent({
+    name: 'TransactionProvider',
+    props: {
+      transaction: {
+        type: Object,
+        required: true
+      }
+    },
+    setup(props, { slots }) {
+      return () => slots.default?.({ status: (props.transaction as any).status, refetch: vi.fn() })
+    }
+  })
+}))
+
+const VIconStub = defineComponent({
+  name: 'VIconStub',
+  props: {
+    icon: {
+      type: String,
+      default: ''
+    },
+    color: {
+      type: String,
+      default: ''
+    }
+  },
+  template: '<i class="v-icon" :data-icon="icon" :data-color="color" />'
+})
+
+const i18n = createI18n({
+  legacy: false,
+  locale: 'en',
+  messages: {
+    en: {
+      chats: {
+        sent_label: 'Sent',
+        received_label: 'Received',
+        you: 'You'
+      }
+    }
+  }
+})
+
+function createStoreMock() {
+  return createStore({
+    state: {
+      options: {
+        formatMessages: false
+      }
+    },
+    modules: {
+      chat: {
+        namespaced: true,
+        getters: {
+          numOfNewMessages: () => () => 0
+        }
+      }
+    }
+  })
+}
+
+function createTransaction(status: (typeof TransactionStatus)[keyof typeof TransactionStatus]) {
+  return {
+    id: 'tx-1',
+    hash: 'tx-1',
+    senderId: 'U1111111111111111111',
+    recipientId: 'U2222222222222222222',
+    admTimestamp: 1,
+    timestamp: Date.now(),
+    confirmations: 0,
+    status,
+    i18n: false,
+    amount: 1,
+    message: 'Color check',
+    height: 1,
+    asset: {
+      type: 'doge_transaction',
+      amount: '1',
+      hash: 'tx-1',
+      comments: 'Color check'
+    },
+    type: 'DOGE'
+  }
+}
+
+function mountPreview(status: (typeof TransactionStatus)[keyof typeof TransactionStatus]) {
+  const store = createStoreMock()
+
+  return mount(ChatPreview, {
+    props: {
+      userId: 'U1111111111111111111',
+      contactId: 'U2222222222222222222',
+      transaction: createTransaction(status)
+    },
+    global: {
+      plugins: [store, i18n],
+      stubs: {
+        VIcon: VIconStub,
+        VListItem: defineComponent({ template: '<div><slot name="prepend" /><slot /></div>' }),
+        VListItemTitle: defineComponent({ template: '<div><slot /></div>' }),
+        VListItemSubtitle: defineComponent({ template: '<div><slot /></div>' }),
+        VBadge: defineComponent({ template: '<div><slot /></div>' })
+      }
+    }
+  })
+}
+
+describe('ChatPreview status colors', () => {
+  it('colors transfer status icons in chat preview and keeps preview text compact', () => {
+    const confirmedWrapper = mountPreview(TransactionStatus.CONFIRMED)
+    const rejectedWrapper = mountPreview(TransactionStatus.REJECTED)
+    const invalidWrapper = mountPreview(TransactionStatus.INVALID)
+
+    expect(confirmedWrapper.find('.v-icon').attributes('data-color')).toBe(
+      tsColor(TransactionStatus.CONFIRMED)
+    )
+    expect(rejectedWrapper.find('.v-icon').attributes('data-color')).toBe(
+      tsColor(TransactionStatus.REJECTED)
+    )
+    expect(invalidWrapper.find('.v-icon').attributes('data-color')).toBe(
+      tsColor(TransactionStatus.INVALID)
+    )
+    expect(confirmedWrapper.text()).toContain('Sent 1 DOGE')
+    expect(confirmedWrapper.text()).not.toContain(' Sent 1 DOGE ')
+  })
+})

--- a/src/components/__tests__/TransactionListItem.test.js
+++ b/src/components/__tests__/TransactionListItem.test.js
@@ -168,4 +168,117 @@ describe('TransactionListItem.vue', () => {
     expect(wrapper.vm.resolvedStatus).toBe('CONFIRMED')
     expect(wrapper.vm.isStatusVisibleTransaction).toBe(false)
   })
+
+  it('falls back to known partner crypto addresses to resolve ADM chat links in transaction lists', async () => {
+    const wrapper = mount(TransactionListItem, {
+      shallow: true,
+      props: {
+        id: 'doge-tx-1',
+        senderId: 'DPartnerAddress',
+        recipientId: 'DMyAddress',
+        amount: 1,
+        status: 'CONFIRMED',
+        timestamp: 1_710_000_000_000,
+        crypto: 'DOGE'
+      },
+      global: {
+        mocks: {
+          $t: (key) => key,
+          $te: () => false,
+          $store: {
+            state: {
+              address: 'UMyAdamantAddress',
+              partners: {
+                list: {
+                  UPartnerAdamantAddress: {
+                    DOGE: 'DPartnerAddress'
+                  }
+                }
+              },
+              doge: {
+                address: 'DMyAddress'
+              },
+              chat: {
+                chats: {}
+              },
+              adm: {
+                transactions: {}
+              }
+            },
+            getters: {
+              'rate/historyRate': () => '42.00 USD',
+              'partners/displayName': (address) =>
+                address === 'UPartnerAdamantAddress' ? 'Doge Partner' : '',
+              'chat/isPartnerInChatList': (address) => address === 'UPartnerAdamantAddress'
+            },
+            dispatch: vi.fn()
+          }
+        }
+      }
+    })
+
+    expect(wrapper.vm.partnerAdmId).toBe('UPartnerAdamantAddress')
+    expect(wrapper.vm.partnerName).toBe('Doge Partner')
+    expect(wrapper.vm.isClickIcon).toBe(true)
+
+    await wrapper.vm.onClickIcon()
+
+    expect(wrapper.emitted('click:icon')).toEqual([['UPartnerAdamantAddress']])
+  })
+
+  it('does not divide ADM live amounts twice when the transaction query already returns ADM units', () => {
+    queryData.value = {
+      id: 'adm-tx-1',
+      senderId: 'U1234567890',
+      recipientId: 'U0987654321',
+      amount: 0.5,
+      status: 'REGISTERED',
+      timestamp: 269_282_595
+    }
+
+    const historyRateGetter = vi.fn(() => '42.00 USD')
+
+    const wrapper = mount(TransactionListItem, {
+      shallow: true,
+      props: {
+        id: 'adm-tx-1',
+        senderId: 'U1234567890',
+        recipientId: 'U0987654321',
+        amount: 50_000_000,
+        status: 'PENDING',
+        timestamp: 269_282_595,
+        crypto: 'ADM'
+      },
+      global: {
+        mocks: {
+          $t: (key) => key,
+          $te: () => false,
+          $store: {
+            state: {
+              address: 'U1234567890',
+              partners: {
+                list: {}
+              },
+              chat: {
+                chats: {}
+              },
+              adm: {
+                transactions: {}
+              }
+            },
+            getters: {
+              'rate/historyRate': historyRateGetter,
+              'partners/displayName': () => '',
+              'chat/isPartnerInChatList': () => false
+            },
+            dispatch: vi.fn()
+          }
+        }
+      }
+    })
+
+    expect(wrapper.text()).toContain('0.5 ADM')
+    expect(wrapper.text()).not.toContain('0.000000005 ADM')
+    expect(historyRateGetter).toHaveBeenCalledWith(1_773_654_195, '0.5', 'ADM')
+  })
 })

--- a/src/components/__tests__/TransactionListItem.test.js
+++ b/src/components/__tests__/TransactionListItem.test.js
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+
+let queryData
+let queryIsFetching
+let queryStatus
+
+vi.mock('@/hooks/queries/transaction', () => {
+  const createMockQuery = () => ({
+    data: queryData,
+    isFetching: queryIsFetching,
+    status: queryStatus,
+    refetch: vi.fn()
+  })
+
+  return {
+    useTransactionQuery: vi.fn(() => createMockQuery()),
+    useTransactionStatusQuery: vi.fn(() => createMockQuery()),
+    useAdmTransactionQuery: vi.fn(() => createMockQuery()),
+    useBtcTransactionQuery: vi.fn(() => createMockQuery()),
+    useDogeTransactionQuery: vi.fn(() => createMockQuery()),
+    useDashTransactionQuery: vi.fn(() => createMockQuery()),
+    useEthTransactionQuery: vi.fn(() => createMockQuery()),
+    useErc20TransactionQuery: vi.fn(() => () => createMockQuery())
+  }
+})
+
+vi.mock('@/components/transactions/hooks/useClearPendingTransaction', () => ({
+  useClearPendingTransaction: vi.fn()
+}))
+
+vi.mock('@/filters/date', () => ({
+  default: vi.fn(() => 'Mar 09, 16:00')
+}))
+
+import TransactionListItem from '@/components/TransactionListItem.vue'
+
+describe('TransactionListItem.vue', () => {
+  beforeEach(() => {
+    queryData = ref(undefined)
+    queryIsFetching = ref(false)
+    queryStatus = ref('success')
+  })
+
+  it('prefers live transaction fields over stale pending props and refetches history rates', async () => {
+    const dispatchSpy = vi.fn()
+
+    queryData.value = {
+      id: 'tx-1',
+      senderId: 'bc1sender',
+      recipientId: 'bc1recipient',
+      amount: 0.25,
+      status: 'REGISTERED',
+      timestamp: 1_710_000_000_000
+    }
+
+    const wrapper = mount(TransactionListItem, {
+      shallow: true,
+      props: {
+        id: 'tx-1',
+        senderId: 'bc1sender',
+        recipientId: 'bc1recipient',
+        amount: 0.1,
+        status: 'PENDING',
+        timestamp: 1_700_000_000_000,
+        crypto: 'BTC'
+      },
+      global: {
+        mocks: {
+          $t: (key) => key,
+          $te: () => false,
+          $store: {
+            state: {
+              address: 'U1234567890',
+              btc: {
+                address: 'bc1sender'
+              },
+              chat: {
+                chats: {}
+              },
+              adm: {
+                transactions: {}
+              }
+            },
+            getters: {
+              'rate/historyRate': () => '42.00 USD',
+              'partners/displayName': () => '',
+              'chat/isPartnerInChatList': () => false
+            },
+            dispatch: dispatchSpy
+          }
+        }
+      }
+    })
+
+    expect(wrapper.vm.resolvedStatus).toBe('REGISTERED')
+    expect(wrapper.vm.resolvedAmount).toBe(0.25)
+    expect(wrapper.vm.resolvedTimestamp).toBe(1_710_000_000_000)
+    expect(dispatchSpy).toHaveBeenCalledWith('rate/getHistoryRates', {
+      timestamp: 1_710_000_000
+    })
+
+    queryData.value = {
+      ...queryData.value,
+      status: 'CONFIRMED',
+      timestamp: 1_710_000_600_000
+    }
+    await nextTick()
+
+    expect(wrapper.vm.resolvedStatus).toBe('CONFIRMED')
+    expect(wrapper.vm.isStatusVisibleTransaction).toBe(false)
+    expect(dispatchSpy).toHaveBeenCalledWith('rate/getHistoryRates', {
+      timestamp: 1_710_000_600
+    })
+  })
+})

--- a/src/components/__tests__/TransactionListItem.test.js
+++ b/src/components/__tests__/TransactionListItem.test.js
@@ -114,4 +114,58 @@ describe('TransactionListItem.vue', () => {
       timestamp: 1_710_000_600
     })
   })
+
+  it('renders Dash InstantSend transactions as successful in the list while details keep polling', () => {
+    queryData.value = {
+      id: 'dash-tx-1',
+      senderId: 'Xsender',
+      recipientId: 'Xrecipient',
+      amount: 0.0013,
+      status: 'REGISTERED',
+      instantsend: true,
+      timestamp: 1_710_000_000_000
+    }
+
+    const wrapper = mount(TransactionListItem, {
+      shallow: true,
+      props: {
+        id: 'dash-tx-1',
+        senderId: 'Xsender',
+        recipientId: 'Xrecipient',
+        amount: 0.0013,
+        status: 'PENDING',
+        timestamp: 1_710_000_000_000,
+        crypto: 'DASH'
+      },
+      global: {
+        mocks: {
+          $t: (key) => key,
+          $te: () => false,
+          $store: {
+            state: {
+              address: 'U1234567890',
+              dash: {
+                address: 'Xsender'
+              },
+              chat: {
+                chats: {}
+              },
+              adm: {
+                transactions: {}
+              }
+            },
+            getters: {
+              'rate/historyRate': () => '42.00 USD',
+              'partners/displayName': () => '',
+              'chat/isPartnerInChatList': () => false
+            },
+            dispatch: vi.fn()
+          }
+        }
+      }
+    })
+
+    expect(wrapper.vm.resolvedStatus).toBe('CONFIRMED')
+    expect(wrapper.vm.isStatusVisibleTransaction).toBe(false)
+  })
 })

--- a/src/components/transactions/AdmTransaction.vue
+++ b/src/components/transactions/AdmTransaction.vue
@@ -66,6 +66,7 @@ export default defineComponent({
       queryStatus,
       statusValue,
       undefined,
+      undefined,
       additionalStatus,
       isLoadingError,
       isRefetchError,

--- a/src/components/transactions/AdmTransaction.vue
+++ b/src/components/transactions/AdmTransaction.vue
@@ -20,6 +20,8 @@ import { computed, defineComponent, PropType } from 'vue'
 import { useStore } from 'vuex'
 import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
+import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
+import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import { useFormatADMAddress } from '@/hooks/address/useFormatADMAddress'
 import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
 import { useAdmTransactionQuery } from '@/hooks/queries/transaction'
@@ -69,6 +71,8 @@ export default defineComponent({
       isRefetchError,
       error
     )
+    const admTx = useFindAdmTransaction(props.id)
+    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
 
     const partnerAdmAddress = computed(() => {
       return transaction.value

--- a/src/components/transactions/AdmTransaction.vue
+++ b/src/components/transactions/AdmTransaction.vue
@@ -49,9 +49,12 @@ export default defineComponent({
       isFetching,
       isLoadingError,
       isRefetchError,
+      error,
       data: transaction,
       refetch
-    } = useAdmTransactionQuery(props.id)
+    } = useAdmTransactionQuery(props.id, {
+      refetchOnMount: true
+    })
     const statusValue = computed<TransactionStatusType | undefined>(
       () => (transaction.value as { status?: TransactionStatusType } | undefined)?.status
     )
@@ -63,7 +66,8 @@ export default defineComponent({
       undefined,
       additionalStatus,
       isLoadingError,
-      isRefetchError
+      isRefetchError,
+      error
     )
 
     const partnerAdmAddress = computed(() => {

--- a/src/components/transactions/AdmTransaction.vue
+++ b/src/components/transactions/AdmTransaction.vue
@@ -47,6 +47,8 @@ export default defineComponent({
     const {
       status: queryStatus,
       isFetching,
+      isLoadingError,
+      isRefetchError,
       data: transaction,
       refetch
     } = useAdmTransactionQuery(props.id)
@@ -59,7 +61,9 @@ export default defineComponent({
       queryStatus,
       statusValue,
       undefined,
-      additionalStatus
+      additionalStatus,
+      isLoadingError,
+      isRefetchError
     )
 
     const partnerAdmAddress = computed(() => {

--- a/src/components/transactions/AdmTransaction.vue
+++ b/src/components/transactions/AdmTransaction.vue
@@ -9,6 +9,7 @@
     :partner="partnerAdmAddress || ''"
     :query-status="queryStatus"
     :transaction-status="transactionStatus"
+    :additional-status="additionalStatus"
     :crypto="crypto"
     @refetch-status="refetch"
   />
@@ -17,13 +18,14 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
 import { useStore } from 'vuex'
+import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useFormatADMAddress } from '@/hooks/address/useFormatADMAddress'
 import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
 import { useAdmTransactionQuery } from '@/hooks/queries/transaction'
 import TransactionTemplate from './TransactionTemplate.vue'
 import { getExplorerTxUrl } from '@/config/utils'
-import { Cryptos, CryptoSymbol } from '@/lib/constants'
+import { Cryptos, CryptoSymbol, TransactionStatusType } from '@/lib/constants'
 import { getPartnerAddress } from './utils/getPartnerAddress'
 
 export default defineComponent({
@@ -48,7 +50,17 @@ export default defineComponent({
       data: transaction,
       refetch
     } = useAdmTransactionQuery(props.id)
-    const transactionStatus = useTransactionStatus(isFetching, queryStatus)
+    const statusValue = computed<TransactionStatusType | undefined>(
+      () => (transaction.value as { status?: TransactionStatusType } | undefined)?.status
+    )
+    const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
+    const transactionStatus = useTransactionStatus(
+      isFetching,
+      queryStatus,
+      statusValue,
+      undefined,
+      additionalStatus
+    )
 
     const partnerAdmAddress = computed(() => {
       return transaction.value
@@ -92,7 +104,8 @@ export default defineComponent({
       explorerLink,
       confirmations,
       queryStatus,
-      transactionStatus
+      transactionStatus,
+      additionalStatus
     }
   }
 })

--- a/src/components/transactions/BtcTransaction.spec.ts
+++ b/src/components/transactions/BtcTransaction.spec.ts
@@ -1,0 +1,160 @@
+import { computed, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import BtcTransaction from './BtcTransaction.vue'
+
+const queryData = ref()
+let mockStore: any
+const admTransaction = ref<any>({
+  senderId: 'U3716604363012166999',
+  recipientId: 'U6386412615727665758'
+})
+
+vi.mock('vuex', () => ({
+  useStore: () => mockStore
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: {}
+  })
+}))
+
+vi.mock('./TransactionTemplate.vue', () => ({
+  default: {
+    name: 'TransactionTemplate',
+    template: '<div />',
+    props: ['partner']
+  }
+}))
+
+vi.mock('@/hooks/queries/transaction', () => ({
+  useBtcTransactionQuery: vi.fn(() => ({
+    status: ref('success'),
+    isFetching: ref(false),
+    isLoadingError: ref(false),
+    isRefetchError: ref(false),
+    error: ref(null),
+    data: queryData,
+    refetch: vi.fn()
+  })),
+  useDogeTransactionQuery: vi.fn(() => ({
+    status: ref('success'),
+    isFetching: ref(false),
+    isLoadingError: ref(false),
+    isRefetchError: ref(false),
+    error: ref(null),
+    data: queryData,
+    refetch: vi.fn()
+  })),
+  useDashTransactionQuery: vi.fn(() => ({
+    status: ref('success'),
+    isFetching: ref(false),
+    isLoadingError: ref(false),
+    isRefetchError: ref(false),
+    error: ref(null),
+    data: queryData,
+    refetch: vi.fn()
+  }))
+}))
+
+vi.mock('./hooks/useTransactionAdditionalStatus', () => ({
+  useTransactionAdditionalStatus: vi.fn(() => computed(() => false))
+}))
+
+vi.mock('./hooks/useTransactionStatus', () => ({
+  useTransactionStatus: vi.fn(() => computed(() => 'CONFIRMED'))
+}))
+
+vi.mock('./hooks/useInconsistentStatus', () => ({
+  useInconsistentStatus: vi.fn(() => computed(() => ''))
+}))
+
+vi.mock('./hooks/useFindAdmTransaction', () => ({
+  useFindAdmTransaction: vi.fn(() => computed(() => admTransaction.value))
+}))
+
+const fallbackAdmAddress = ref('')
+
+vi.mock('./hooks/useFindAdmAddress', () => ({
+  useFindAdmAddress: vi.fn(() => computed(() => fallbackAdmAddress.value))
+}))
+
+vi.mock('./hooks/useSyncChatTransferPendingStatus', () => ({
+  useSyncChatTransferPendingStatus: vi.fn()
+}))
+
+vi.mock('./hooks/useClearPendingTransaction', () => ({
+  useClearPendingTransaction: vi.fn()
+}))
+
+vi.mock('@/hooks/queries/useBlockHeight', () => ({
+  useBlockHeight: vi.fn(() => computed(() => 100))
+}))
+
+vi.mock('./hooks/address', () => ({
+  useBtcAddressPretty: vi.fn(() => computed(() => 'formatted'))
+}))
+
+vi.mock('@/config/utils', () => ({
+  getExplorerTxUrl: vi.fn(() => 'https://example.com')
+}))
+
+describe('BtcTransaction.vue', () => {
+  beforeEach(() => {
+    fallbackAdmAddress.value = ''
+    admTransaction.value = {
+      senderId: 'U3716604363012166999',
+      recipientId: 'U6386412615727665758'
+    }
+    mockStore = {
+      state: {
+        address: 'U3716604363012166999',
+        doge: {
+          address: 'DJYzxc6Rd3tknUmED7KB83ZoXV9NzhZxss'
+        }
+      }
+    }
+
+    queryData.value = {
+      id: '723a8f9d1f0083b5da91c2aae1df6434d854828d8e9fac5f11b30f021af3ba86',
+      senderId: 'DJYzxc6Rd3tknUmED7KB83ZoXV9NzhZxss',
+      recipientId: 'DCh27PcKiPGFQSr92QLbVbcPZ1rJNVfqZH',
+      amount: 1,
+      fee: 1,
+      status: 'CONFIRMED',
+      confirmations: 1
+    }
+  })
+
+  it('uses the current ADM address to compute continue-chat partner for DOGE details', () => {
+    const wrapper = mount(BtcTransaction, {
+      props: {
+        id: '723a8f9d1f0083b5da91c2aae1df6434d854828d8e9fac5f11b30f021af3ba86',
+        crypto: 'DOGE'
+      }
+    })
+
+    expect(wrapper.vm.partnerAdmAddress).toBe('U6386412615727665758')
+    expect(wrapper.findComponent({ name: 'TransactionTemplate' }).props('partner')).toBe(
+      'U6386412615727665758'
+    )
+  })
+
+  it('keeps continue-chat partner available from partners fallback when admTx is not in chat memory', () => {
+    fallbackAdmAddress.value = 'U6386412615727665758'
+    admTransaction.value = undefined
+
+    const wrapper = mount(BtcTransaction, {
+      props: {
+        id: '723a8f9d1f0083b5da91c2aae1df6434d854828d8e9fac5f11b30f021af3ba86',
+        crypto: 'DOGE'
+      }
+    })
+
+    expect(wrapper.vm.partnerAdmAddress).toBe('U6386412615727665758')
+    expect(wrapper.findComponent({ name: 'TransactionTemplate' }).props('partner')).toBe(
+      'U6386412615727665758'
+    )
+  })
+})

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -29,6 +29,7 @@ import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditional
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
+import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import {
   useBtcTransactionQuery,
   useDogeTransactionQuery,
@@ -91,6 +92,7 @@ export default defineComponent({
     useClearPendingTransaction(props.crypto, transaction, status)
 
     const admTx = useFindAdmTransaction(props.id)
+    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
     const senderAdmAddress = computed(() => admTx.value?.senderId || '')
     const recipientAdmAddress = computed(() => admTx.value?.recipientId || '')
     const partnerAdmAddress = computed(() =>

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -76,7 +76,7 @@ export default defineComponent({
       transactionStatus,
       inconsistentStatus
     )
-    useClearPendingTransaction(props.crypto, transaction)
+    useClearPendingTransaction(props.crypto, transaction, status)
 
     const admTx = useFindAdmTransaction(props.id)
     const senderAdmAddress = computed(() => admTx.value?.senderId || '')

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -67,6 +67,8 @@ export default defineComponent({
     const {
       status: queryStatus,
       isFetching,
+      isLoadingError,
+      isRefetchError,
       data: transaction,
       refetch
     } = useTransactionQuery(props.id)
@@ -78,7 +80,9 @@ export default defineComponent({
       queryStatus,
       transactionStatus,
       inconsistentStatus,
-      additionalStatus
+      additionalStatus,
+      isLoadingError,
+      isRefetchError
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -69,9 +69,12 @@ export default defineComponent({
       isFetching,
       isLoadingError,
       isRefetchError,
+      error,
       data: transaction,
       refetch
-    } = useTransactionQuery(props.id)
+    } = useTransactionQuery(props.id, {
+      refetchOnMount: true
+    })
     const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
     const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
     const transactionStatus = computed(() => transaction.value?.status)
@@ -82,7 +85,8 @@ export default defineComponent({
       inconsistentStatus,
       additionalStatus,
       isLoadingError,
-      isRefetchError
+      isRefetchError,
+      error
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -20,6 +20,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
 import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
 import TransactionTemplate from './TransactionTemplate.vue'
 import { getExplorerTxUrl } from '@/config/utils'
 import { CryptoSymbol } from '@/lib/constants'
@@ -28,6 +29,7 @@ import { useBtcAddressPretty } from './hooks/address'
 import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
+import { useFindAdmAddress } from './hooks/useFindAdmAddress'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
 import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import {
@@ -37,6 +39,7 @@ import {
 } from '@/hooks/queries/transaction'
 import { useClearPendingTransaction } from './hooks/useClearPendingTransaction'
 import { getPartnerAddress } from './utils/getPartnerAddress'
+import { isStringEqualCI } from '@/lib/textHelpers'
 
 const query = {
   BTC: useBtcTransactionQuery,
@@ -60,9 +63,16 @@ export default defineComponent({
   },
   setup(props) {
     const store = useStore()
+    const route = useRoute()
 
     const cryptoKey = computed(() => props.crypto.toLowerCase())
     const cryptoAddress = computed(() => store.state[cryptoKey.value].address)
+    const myAdmAddress = computed(() => store.state.address)
+    const preferredPartnerId = computed(() =>
+      typeof route.query.from === 'string'
+        ? route.query.from.match(/\/chats\/([^/]+)/)?.[1] || ''
+        : ''
+    )
 
     const useTransactionQuery = query[props.crypto]
     const {
@@ -76,7 +86,8 @@ export default defineComponent({
     } = useTransactionQuery(props.id, {
       refetchOnMount: true
     })
-    const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
+    const admTx = useFindAdmTransaction(props.id, preferredPartnerId)
+    const inconsistentStatus = useInconsistentStatus(transaction, props.crypto, admTx)
     const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
     const transactionStatus = computed(() => transaction.value?.status)
     const status = useTransactionStatus(
@@ -91,15 +102,61 @@ export default defineComponent({
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 
-    const admTx = useFindAdmTransaction(props.id)
-    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
-    const senderAdmAddress = computed(() => admTx.value?.senderId || '')
-    const recipientAdmAddress = computed(() => admTx.value?.recipientId || '')
-    const partnerAdmAddress = computed(() =>
-      admTx.value
-        ? getPartnerAddress(admTx.value?.senderId, admTx.value?.recipientId, cryptoAddress.value)
-        : ''
+    const senderFallbackAdmAddress = useFindAdmAddress(
+      computed(() => props.crypto),
+      computed(() => transaction.value?.senderId || ''),
+      computed(() => props.id)
     )
+    const recipientFallbackAdmAddress = useFindAdmAddress(
+      computed(() => props.crypto),
+      computed(() => transaction.value?.recipientId || ''),
+      computed(() => props.id)
+    )
+    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
+    const senderAdmAddress = computed(() => {
+      if (admTx.value?.senderId) {
+        return admTx.value.senderId
+      }
+
+      if (isStringEqualCI(transaction.value?.senderId || '', cryptoAddress.value)) {
+        return myAdmAddress.value
+      }
+
+      return senderFallbackAdmAddress.value || ''
+    })
+    const recipientAdmAddress = computed(() => {
+      if (admTx.value?.recipientId) {
+        return admTx.value.recipientId
+      }
+
+      if (isStringEqualCI(transaction.value?.recipientId || '', cryptoAddress.value)) {
+        return myAdmAddress.value
+      }
+
+      return recipientFallbackAdmAddress.value || ''
+    })
+    const partnerAdmAddress = computed(() => {
+      if (senderAdmAddress.value && recipientAdmAddress.value) {
+        return getPartnerAddress(
+          senderAdmAddress.value,
+          recipientAdmAddress.value,
+          myAdmAddress.value
+        )
+      }
+
+      if (senderAdmAddress.value && !isStringEqualCI(senderAdmAddress.value, myAdmAddress.value)) {
+        return senderAdmAddress.value
+      }
+
+      if (
+        recipientAdmAddress.value &&
+        !isStringEqualCI(recipientAdmAddress.value, myAdmAddress.value)
+      ) {
+        return recipientAdmAddress.value
+      }
+
+      return ''
+    })
 
     const senderFormatted = useBtcAddressPretty(
       transaction,

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -95,6 +95,7 @@ export default defineComponent({
       queryStatus,
       transactionStatus,
       inconsistentStatus,
+      undefined,
       additionalStatus,
       isLoadingError,
       isRefetchError,

--- a/src/components/transactions/BtcTransaction.vue
+++ b/src/components/transactions/BtcTransaction.vue
@@ -9,6 +9,7 @@
     :partner="partnerAdmAddress || ''"
     :query-status="queryStatus"
     :transaction-status="status"
+    :additional-status="additionalStatus"
     :inconsistent-status="inconsistentStatus"
     :adm-tx="admTx"
     :crypto="crypto"
@@ -24,6 +25,7 @@ import { getExplorerTxUrl } from '@/config/utils'
 import { CryptoSymbol } from '@/lib/constants'
 import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
 import { useBtcAddressPretty } from './hooks/address'
+import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
@@ -69,12 +71,14 @@ export default defineComponent({
       refetch
     } = useTransactionQuery(props.id)
     const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
+    const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
     const transactionStatus = computed(() => transaction.value?.status)
     const status = useTransactionStatus(
       isFetching,
       queryStatus,
       transactionStatus,
-      inconsistentStatus
+      inconsistentStatus,
+      additionalStatus
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 
@@ -132,6 +136,7 @@ export default defineComponent({
       admTx,
       queryStatus,
       status,
+      additionalStatus,
       inconsistentStatus
     }
   }

--- a/src/components/transactions/Erc20Transaction.spec.ts
+++ b/src/components/transactions/Erc20Transaction.spec.ts
@@ -1,0 +1,135 @@
+import { computed, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import Erc20Transaction from './Erc20Transaction.vue'
+
+const queryData = ref()
+const admTransaction = ref<any>({
+  senderId: 'U3716604363012166999',
+  recipientId: 'U5587801118512880053'
+})
+const { useInconsistentStatusMock, capturedKnownAdmTransaction } = vi.hoisted(() => ({
+  capturedKnownAdmTransaction: {
+    current: undefined as { value: unknown } | undefined
+  },
+  useInconsistentStatusMock: vi.fn(
+    (_transaction?: unknown, _crypto?: unknown, knownAdmTransaction?: { value: unknown }) => {
+      capturedKnownAdmTransaction.current = knownAdmTransaction
+
+      return computed(() => {
+        return ''
+      })
+    }
+  )
+}))
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    state: {
+      address: 'U3716604363012166999',
+      eth: {
+        address: '0x1111111111111111111111111111111111111111'
+      }
+    }
+  })
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    query: {
+      from: '/chats/U5587801118512880053'
+    }
+  })
+}))
+
+vi.mock('./TransactionTemplate.vue', () => ({
+  default: {
+    name: 'TransactionTemplate',
+    template: '<div />'
+  }
+}))
+
+vi.mock('@/hooks/queries/transaction', () => ({
+  useErc20TransactionQuery: vi.fn(() => () => ({
+    status: ref('success'),
+    isFetching: ref(false),
+    isLoadingError: ref(false),
+    isRefetchError: ref(false),
+    error: ref(null),
+    data: queryData,
+    refetch: vi.fn()
+  }))
+}))
+
+vi.mock('./hooks/useTransactionAdditionalStatus', () => ({
+  useTransactionAdditionalStatus: vi.fn(() => computed(() => false))
+}))
+
+vi.mock('./hooks/useTransactionStatus', () => ({
+  useTransactionStatus: vi.fn(() => computed(() => 'CONFIRMED'))
+}))
+
+vi.mock('./hooks/useInconsistentStatus', () => ({
+  useInconsistentStatus: useInconsistentStatusMock
+}))
+
+vi.mock('./hooks/useFindAdmTransaction', () => ({
+  useFindAdmTransaction: vi.fn(() => computed(() => admTransaction.value))
+}))
+
+vi.mock('./hooks/useFindAdmAddress', () => ({
+  useFindAdmAddress: vi.fn(() => computed(() => ''))
+}))
+
+vi.mock('./hooks/useSyncChatTransferPendingStatus', () => ({
+  useSyncChatTransferPendingStatus: vi.fn()
+}))
+
+vi.mock('./hooks/useClearPendingTransaction', () => ({
+  useClearPendingTransaction: vi.fn()
+}))
+
+vi.mock('@/hooks/queries/useBlockHeight', () => ({
+  useBlockHeight: vi.fn(() => computed(() => 100))
+}))
+
+vi.mock('./hooks/address', () => ({
+  useCryptoAddressPretty: vi.fn(() => computed(() => 'formatted'))
+}))
+
+vi.mock('@/config/utils', () => ({
+  getExplorerTxUrl: vi.fn(() => 'https://example.com')
+}))
+
+describe('Erc20Transaction.vue', () => {
+  beforeEach(() => {
+    useInconsistentStatusMock.mockClear()
+    capturedKnownAdmTransaction.current = undefined
+    admTransaction.value = {
+      senderId: 'U3716604363012166999',
+      recipientId: 'U5587801118512880053'
+    }
+    queryData.value = {
+      id: '0x0a31625a6b7e9a227bbaba608f1a48d2bd515a733f2b5e6e3cf38191f9c8efdc',
+      senderId: '0x1111111111111111111111111111111111111111',
+      recipientId: '0x2222222222222222222222222222222222222222',
+      amount: 1,
+      fee: 0.1,
+      status: 'CONFIRMED',
+      confirmations: 1,
+      blockNumber: 99
+    }
+  })
+
+  it('passes the current chat ADM transaction into inconsistency checks', () => {
+    mount(Erc20Transaction, {
+      props: {
+        id: '0x0a31625a6b7e9a227bbaba608f1a48d2bd515a733f2b5e6e3cf38191f9c8efdc',
+        crypto: 'USDT'
+      }
+    })
+
+    expect(useInconsistentStatusMock).toHaveBeenCalledTimes(1)
+    expect(capturedKnownAdmTransaction.current?.value).toEqual(admTransaction.value)
+  })
+})

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -53,6 +53,8 @@ const cryptoAddress = computed(() => store.state.eth.address)
 const {
   status: queryStatus,
   isFetching,
+  isLoadingError,
+  isRefetchError,
   data: transaction,
   refetch
 } = useErc20TransactionQuery(props.crypto)(props.id)
@@ -64,7 +66,9 @@ const status = useTransactionStatus(
   queryStatus,
   transactionStatus,
   inconsistentStatus,
-  additionalStatus
+  additionalStatus,
+  isLoadingError,
+  isRefetchError
 )
 useClearPendingTransaction(props.crypto, transaction, status)
 

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -21,6 +21,7 @@
 <script lang="ts" setup>
 import { computed, PropType } from 'vue'
 import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
 import TransactionTemplate from './TransactionTemplate.vue'
 import { getExplorerTxUrl } from '@/config/utils'
 import { Cryptos, CryptoSymbol } from '@/lib/constants'
@@ -30,11 +31,13 @@ import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
 import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
+import { useFindAdmAddress } from './hooks/useFindAdmAddress'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
 import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import { useErc20TransactionQuery } from '@/hooks/queries/transaction'
 import { useClearPendingTransaction } from './hooks/useClearPendingTransaction'
 import { getPartnerAddress } from './utils/getPartnerAddress'
+import { isStringEqualCI } from '@/lib/textHelpers'
 
 const props = defineProps({
   crypto: {
@@ -48,8 +51,13 @@ const props = defineProps({
 })
 
 const store = useStore()
+const route = useRoute()
 
 const cryptoAddress = computed(() => store.state.eth.address)
+const myAdmAddress = computed(() => store.state.address)
+const preferredPartnerId = computed(() =>
+  typeof route.query.from === 'string' ? route.query.from.match(/\/chats\/([^/]+)/)?.[1] || '' : ''
+)
 
 const {
   status: queryStatus,
@@ -62,7 +70,8 @@ const {
 } = useErc20TransactionQuery(props.crypto)(props.id, {
   refetchOnMount: true
 })
-const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
+const admTx = useFindAdmTransaction(props.id, preferredPartnerId)
+const inconsistentStatus = useInconsistentStatus(transaction, props.crypto, admTx)
 const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
 const transactionStatus = computed(() => transaction.value?.status)
 const status = useTransactionStatus(
@@ -77,15 +86,57 @@ const status = useTransactionStatus(
 )
 useClearPendingTransaction(props.crypto, transaction, status)
 
-const admTx = useFindAdmTransaction(props.id)
-useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
-const senderAdmAddress = computed(() => admTx.value?.senderId || '')
-const recipientAdmAddress = computed(() => admTx.value?.recipientId || '')
-const partnerAdmAddress = computed(() =>
-  admTx.value
-    ? getPartnerAddress(admTx.value?.senderId, admTx.value?.recipientId, cryptoAddress.value)
-    : ''
+const senderFallbackAdmAddress = useFindAdmAddress(
+  computed(() => props.crypto),
+  computed(() => transaction.value?.senderId || ''),
+  computed(() => props.id)
 )
+const recipientFallbackAdmAddress = useFindAdmAddress(
+  computed(() => props.crypto),
+  computed(() => transaction.value?.recipientId || ''),
+  computed(() => props.id)
+)
+useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
+const senderAdmAddress = computed(() => {
+  if (admTx.value?.senderId) {
+    return admTx.value.senderId
+  }
+
+  if (isStringEqualCI(transaction.value?.senderId || '', cryptoAddress.value)) {
+    return myAdmAddress.value
+  }
+
+  return senderFallbackAdmAddress.value || ''
+})
+const recipientAdmAddress = computed(() => {
+  if (admTx.value?.recipientId) {
+    return admTx.value.recipientId
+  }
+
+  if (isStringEqualCI(transaction.value?.recipientId || '', cryptoAddress.value)) {
+    return myAdmAddress.value
+  }
+
+  return recipientFallbackAdmAddress.value || ''
+})
+const partnerAdmAddress = computed(() => {
+  if (senderAdmAddress.value && recipientAdmAddress.value) {
+    return getPartnerAddress(senderAdmAddress.value, recipientAdmAddress.value, myAdmAddress.value)
+  }
+
+  if (senderAdmAddress.value && !isStringEqualCI(senderAdmAddress.value, myAdmAddress.value)) {
+    return senderAdmAddress.value
+  }
+
+  if (
+    recipientAdmAddress.value &&
+    !isStringEqualCI(recipientAdmAddress.value, myAdmAddress.value)
+  ) {
+    return recipientAdmAddress.value
+  }
+
+  return ''
+})
 
 const senderFormatted = useCryptoAddressPretty(
   transaction,

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -31,6 +31,7 @@ import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditional
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
+import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import { useErc20TransactionQuery } from '@/hooks/queries/transaction'
 import { useClearPendingTransaction } from './hooks/useClearPendingTransaction'
 import { getPartnerAddress } from './utils/getPartnerAddress'
@@ -77,6 +78,7 @@ const status = useTransactionStatus(
 useClearPendingTransaction(props.crypto, transaction, status)
 
 const admTx = useFindAdmTransaction(props.id)
+useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
 const senderAdmAddress = computed(() => admTx.value?.senderId || '')
 const recipientAdmAddress = computed(() => admTx.value?.recipientId || '')
 const partnerAdmAddress = computed(() =>

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -79,6 +79,7 @@ const status = useTransactionStatus(
   queryStatus,
   transactionStatus,
   inconsistentStatus,
+  undefined,
   additionalStatus,
   isLoadingError,
   isRefetchError,

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -57,7 +57,7 @@ const {
 const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
 const transactionStatus = computed(() => transaction.value?.status)
 const status = useTransactionStatus(isFetching, queryStatus, transactionStatus, inconsistentStatus)
-useClearPendingTransaction(props.crypto, transaction)
+useClearPendingTransaction(props.crypto, transaction, status)
 
 const admTx = useFindAdmTransaction(props.id)
 const senderAdmAddress = computed(() => admTx.value?.senderId || '')

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -55,9 +55,12 @@ const {
   isFetching,
   isLoadingError,
   isRefetchError,
+  error,
   data: transaction,
   refetch
-} = useErc20TransactionQuery(props.crypto)(props.id)
+} = useErc20TransactionQuery(props.crypto)(props.id, {
+  refetchOnMount: true
+})
 const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
 const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
 const transactionStatus = computed(() => transaction.value?.status)
@@ -68,7 +71,8 @@ const status = useTransactionStatus(
   inconsistentStatus,
   additionalStatus,
   isLoadingError,
-  isRefetchError
+  isRefetchError,
+  error
 )
 useClearPendingTransaction(props.crypto, transaction, status)
 

--- a/src/components/transactions/Erc20Transaction.vue
+++ b/src/components/transactions/Erc20Transaction.vue
@@ -9,6 +9,7 @@
     :partner="partnerAdmAddress || ''"
     :query-status="queryStatus"
     :transaction-status="status"
+    :additional-status="additionalStatus"
     :inconsistent-status="inconsistentStatus"
     :adm-tx="admTx"
     :crypto="crypto"
@@ -26,6 +27,7 @@ import { Cryptos, CryptoSymbol } from '@/lib/constants'
 import { AllCryptos } from '@/lib/constants/cryptos'
 import { useCryptoAddressPretty } from './hooks/address'
 import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
+import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
@@ -55,8 +57,15 @@ const {
   refetch
 } = useErc20TransactionQuery(props.crypto)(props.id)
 const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
+const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
 const transactionStatus = computed(() => transaction.value?.status)
-const status = useTransactionStatus(isFetching, queryStatus, transactionStatus, inconsistentStatus)
+const status = useTransactionStatus(
+  isFetching,
+  queryStatus,
+  transactionStatus,
+  inconsistentStatus,
+  additionalStatus
+)
 useClearPendingTransaction(props.crypto, transaction, status)
 
 const admTx = useFindAdmTransaction(props.id)

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -55,6 +55,8 @@ export default defineComponent({
     const {
       status: queryStatus,
       isFetching,
+      isLoadingError,
+      isRefetchError,
       data: transaction,
       refetch
     } = useEthTransactionQuery(props.id)
@@ -66,7 +68,9 @@ export default defineComponent({
       queryStatus,
       transactionStatus,
       inconsistentStatus,
-      additionalStatus
+      additionalStatus,
+      isLoadingError,
+      isRefetchError
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -64,7 +64,7 @@ export default defineComponent({
       transactionStatus,
       inconsistentStatus
     )
-    useClearPendingTransaction(props.crypto, transaction)
+    useClearPendingTransaction(props.crypto, transaction, status)
 
     const admTx = useFindAdmTransaction(props.id)
     const senderAdmAddress = computed(() => admTx.value?.senderId || '')

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -28,6 +28,7 @@ import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditional
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
+import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
 import { useEthTransactionQuery } from '@/hooks/queries/transaction'
 import { useClearPendingTransaction } from './hooks/useClearPendingTransaction'
@@ -79,6 +80,7 @@ export default defineComponent({
     useClearPendingTransaction(props.crypto, transaction, status)
 
     const admTx = useFindAdmTransaction(props.id)
+    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
     const senderAdmAddress = computed(() => admTx.value?.senderId || '')
     const recipientAdmAddress = computed(() => admTx.value?.recipientId || '')
     const partnerAdmAddress = computed(() =>

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -83,6 +83,7 @@ export default defineComponent({
       queryStatus,
       transactionStatus,
       inconsistentStatus,
+      undefined,
       additionalStatus,
       isLoadingError,
       isRefetchError,

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -9,6 +9,7 @@
     :partner="partnerAdmAddress || ''"
     :query-status="queryStatus"
     :transaction-status="status"
+    :additional-status="additionalStatus"
     :inconsistent-status="inconsistentStatus"
     :adm-tx="admTx"
     :crypto="crypto"
@@ -23,6 +24,7 @@ import TransactionTemplate from './TransactionTemplate.vue'
 import { getExplorerTxUrl } from '@/config/utils'
 import { Cryptos, CryptoSymbol } from '@/lib/constants'
 import { useCryptoAddressPretty } from './hooks/address'
+import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
@@ -57,12 +59,14 @@ export default defineComponent({
       refetch
     } = useEthTransactionQuery(props.id)
     const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
+    const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
     const transactionStatus = computed(() => transaction.value?.status)
     const status = useTransactionStatus(
       isFetching,
       queryStatus,
       transactionStatus,
-      inconsistentStatus
+      inconsistentStatus,
+      additionalStatus
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 
@@ -115,6 +119,7 @@ export default defineComponent({
       admTx,
       queryStatus,
       status,
+      additionalStatus,
       inconsistentStatus
     }
   }

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -20,6 +20,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
 import { useStore } from 'vuex'
+import { useRoute } from 'vue-router'
 import TransactionTemplate from './TransactionTemplate.vue'
 import { getExplorerTxUrl } from '@/config/utils'
 import { Cryptos, CryptoSymbol } from '@/lib/constants'
@@ -27,12 +28,14 @@ import { useCryptoAddressPretty } from './hooks/address'
 import { useTransactionAdditionalStatus } from './hooks/useTransactionAdditionalStatus'
 import { useTransactionStatus } from './hooks/useTransactionStatus'
 import { useInconsistentStatus } from './hooks/useInconsistentStatus'
+import { useFindAdmAddress } from './hooks/useFindAdmAddress'
 import { useFindAdmTransaction } from './hooks/useFindAdmTransaction'
 import { useSyncChatTransferPendingStatus } from './hooks/useSyncChatTransferPendingStatus'
 import { useBlockHeight } from '@/hooks/queries/useBlockHeight'
 import { useEthTransactionQuery } from '@/hooks/queries/transaction'
 import { useClearPendingTransaction } from './hooks/useClearPendingTransaction'
 import { getPartnerAddress } from './utils/getPartnerAddress'
+import { isStringEqualCI } from '@/lib/textHelpers'
 
 export default defineComponent({
   components: {
@@ -50,8 +53,15 @@ export default defineComponent({
   },
   setup(props) {
     const store = useStore()
+    const route = useRoute()
 
     const cryptoAddress = computed(() => store.state.eth.address)
+    const myAdmAddress = computed(() => store.state.address)
+    const preferredPartnerId = computed(() =>
+      typeof route.query.from === 'string'
+        ? route.query.from.match(/\/chats\/([^/]+)/)?.[1] || ''
+        : ''
+    )
 
     const {
       status: queryStatus,
@@ -64,7 +74,8 @@ export default defineComponent({
     } = useEthTransactionQuery(props.id, {
       refetchOnMount: true
     })
-    const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
+    const admTx = useFindAdmTransaction(props.id, preferredPartnerId)
+    const inconsistentStatus = useInconsistentStatus(transaction, props.crypto, admTx)
     const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
     const transactionStatus = computed(() => transaction.value?.status)
     const status = useTransactionStatus(
@@ -79,15 +90,61 @@ export default defineComponent({
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 
-    const admTx = useFindAdmTransaction(props.id)
-    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
-    const senderAdmAddress = computed(() => admTx.value?.senderId || '')
-    const recipientAdmAddress = computed(() => admTx.value?.recipientId || '')
-    const partnerAdmAddress = computed(() =>
-      admTx.value
-        ? getPartnerAddress(admTx.value?.senderId, admTx.value?.recipientId, cryptoAddress.value)
-        : ''
+    const senderFallbackAdmAddress = useFindAdmAddress(
+      computed(() => props.crypto),
+      computed(() => transaction.value?.senderId || ''),
+      computed(() => props.id)
     )
+    const recipientFallbackAdmAddress = useFindAdmAddress(
+      computed(() => props.crypto),
+      computed(() => transaction.value?.recipientId || ''),
+      computed(() => props.id)
+    )
+    useSyncChatTransferPendingStatus(props.crypto, props.id, admTx, isFetching, queryStatus)
+    const senderAdmAddress = computed(() => {
+      if (admTx.value?.senderId) {
+        return admTx.value.senderId
+      }
+
+      if (isStringEqualCI(transaction.value?.senderId || '', cryptoAddress.value)) {
+        return myAdmAddress.value
+      }
+
+      return senderFallbackAdmAddress.value || ''
+    })
+    const recipientAdmAddress = computed(() => {
+      if (admTx.value?.recipientId) {
+        return admTx.value.recipientId
+      }
+
+      if (isStringEqualCI(transaction.value?.recipientId || '', cryptoAddress.value)) {
+        return myAdmAddress.value
+      }
+
+      return recipientFallbackAdmAddress.value || ''
+    })
+    const partnerAdmAddress = computed(() => {
+      if (senderAdmAddress.value && recipientAdmAddress.value) {
+        return getPartnerAddress(
+          senderAdmAddress.value,
+          recipientAdmAddress.value,
+          myAdmAddress.value
+        )
+      }
+
+      if (senderAdmAddress.value && !isStringEqualCI(senderAdmAddress.value, myAdmAddress.value)) {
+        return senderAdmAddress.value
+      }
+
+      if (
+        recipientAdmAddress.value &&
+        !isStringEqualCI(recipientAdmAddress.value, myAdmAddress.value)
+      ) {
+        return recipientAdmAddress.value
+      }
+
+      return ''
+    })
 
     const senderFormatted = useCryptoAddressPretty(
       transaction,

--- a/src/components/transactions/EthTransaction.vue
+++ b/src/components/transactions/EthTransaction.vue
@@ -57,9 +57,12 @@ export default defineComponent({
       isFetching,
       isLoadingError,
       isRefetchError,
+      error,
       data: transaction,
       refetch
-    } = useEthTransactionQuery(props.id)
+    } = useEthTransactionQuery(props.id, {
+      refetchOnMount: true
+    })
     const inconsistentStatus = useInconsistentStatus(transaction, props.crypto)
     const additionalStatus = useTransactionAdditionalStatus(transaction, props.crypto)
     const transactionStatus = computed(() => transaction.value?.status)
@@ -70,7 +73,8 @@ export default defineComponent({
       inconsistentStatus,
       additionalStatus,
       isLoadingError,
-      isRefetchError
+      isRefetchError,
+      error
     )
     useClearPendingTransaction(props.crypto, transaction, status)
 

--- a/src/components/transactions/TransactionTemplate.vue
+++ b/src/components/transactions/TransactionTemplate.vue
@@ -168,8 +168,8 @@ import {
   TransactionStatusType,
   tsUpdatable
 } from '@/lib/constants'
-import { DecodedChatMessageTransaction } from '@/lib/adamant-api'
-import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
+import type { DecodedChatMessageTransaction } from '@/lib/adamant-api'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 import { InconsistentStatus } from './utils/getInconsistentStatus'
 import { PendingTransaction } from '@/lib/pending-transactions'
 import { AnyCoinTransaction } from '@/lib/nodes/types/transaction'

--- a/src/components/transactions/TransactionTemplate.vue
+++ b/src/components/transactions/TransactionTemplate.vue
@@ -50,8 +50,8 @@
         {{ formattedTransactionStatus
         }}<span v-if="inconsistentStatus">{{
           ': ' + t(`transaction.inconsistent_reasons.${inconsistentStatus}`, { crypto })
-        }}</span>
-        <!--            <span v-if="status.addStatus">{{ ': ' + status.addDescription }}</span>-->
+        }}</span
+        ><span v-else-if="formattedAdditionalStatus">{{ `: ${formattedAdditionalStatus}` }}</span>
       </div>
     </v-list-item>
 
@@ -163,6 +163,7 @@ import {
   CryptosInfo,
   CryptoSymbol,
   Symbols,
+  TransactionAdditionalStatusType,
   TransactionStatus,
   TransactionStatusType,
   tsUpdatable
@@ -214,6 +215,10 @@ const props = defineProps({
   transactionStatus: {
     type: String as PropType<TransactionStatusType>,
     required: true
+  },
+  additionalStatus: {
+    type: [String, Boolean] as PropType<TransactionAdditionalStatusType>,
+    default: false
   },
   inconsistentStatus: {
     type: String as PropType<InconsistentStatus>
@@ -281,6 +286,14 @@ const formattedTransactionStatus = computed(() => {
   if (isPendingQuery.value) return Symbols.HOURGLASS
 
   return t(`transaction.statuses.${props.transactionStatus}`)
+})
+
+const formattedAdditionalStatus = computed(() => {
+  if (!props.additionalStatus) {
+    return ''
+  }
+
+  return t(`transaction.statuses_add.${props.additionalStatus}`)
 })
 
 const statusUpdatable = computed(() => tsUpdatable(props.transactionStatus, props.crypto))

--- a/src/components/transactions/hooks/useClearPendingTransaction.spec.ts
+++ b/src/components/transactions/hooks/useClearPendingTransaction.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { useClearPendingTransaction } from './useClearPendingTransaction'
+
+const pendingTxStoreMock = vi.hoisted(() => ({
+  get: vi.fn(),
+  remove: vi.fn()
+}))
+
+vi.mock('@/lib/pending-transactions', () => ({
+  PendingTxStore: pendingTxStoreMock
+}))
+
+const createStoreMock = () => {
+  return createStore({
+    modules: {
+      btc: {
+        namespaced: true,
+        actions: {
+          getNewTransactions: vi.fn()
+        }
+      }
+    }
+  })
+}
+
+describe('useClearPendingTransaction', () => {
+  it('refreshes BTC transactions when a pending transaction becomes registered', async () => {
+    pendingTxStoreMock.get.mockReturnValue({ id: 'tx-1' })
+
+    const store = createStoreMock()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    const transaction = ref({
+      id: 'tx-1',
+      status: 'PENDING'
+    })
+    const status = ref('PENDING')
+
+    const TestComponent = defineComponent({
+      setup() {
+        useClearPendingTransaction('BTC', transaction as any, status as any)
+        return () => h('div')
+      }
+    })
+
+    mount(TestComponent, {
+      global: {
+        plugins: [store]
+      }
+    })
+
+    status.value = 'REGISTERED'
+    await nextTick()
+
+    expect(dispatchSpy).toHaveBeenCalledWith('btc/getNewTransactions')
+    expect(pendingTxStoreMock.remove).not.toHaveBeenCalled()
+  })
+
+  it('removes pending transaction and refreshes BTC list when status becomes rejected', async () => {
+    pendingTxStoreMock.get.mockReturnValue({ id: 'tx-1' })
+
+    const store = createStoreMock()
+    const dispatchSpy = vi.spyOn(store, 'dispatch')
+
+    const transaction = ref({
+      id: 'tx-1',
+      status: 'PENDING'
+    })
+    const status = ref('PENDING')
+
+    const TestComponent = defineComponent({
+      setup() {
+        useClearPendingTransaction('BTC', transaction as any, status as any)
+        return () => h('div')
+      }
+    })
+
+    mount(TestComponent, {
+      global: {
+        plugins: [store]
+      }
+    })
+
+    status.value = 'REJECTED'
+    await nextTick()
+
+    expect(pendingTxStoreMock.remove).toHaveBeenCalledWith('BTC')
+    expect(dispatchSpy).toHaveBeenCalledWith('btc/getNewTransactions')
+  })
+})

--- a/src/components/transactions/hooks/useClearPendingTransaction.ts
+++ b/src/components/transactions/hooks/useClearPendingTransaction.ts
@@ -1,31 +1,43 @@
-import { MaybeRef, Ref, unref, watch } from 'vue'
+import { computed, MaybeRef, Ref, unref, watch } from 'vue'
 import { useStore } from 'vuex'
-import { CryptoSymbol, TransactionStatus } from '@/lib/constants'
+import { CryptoSymbol, TransactionStatus, TransactionStatusType } from '@/lib/constants'
 import { CoinTransaction } from '@/lib/nodes/types/transaction'
 import { PendingTxStore } from '@/lib/pending-transactions'
 
 export function useClearPendingTransaction(
   crypto: MaybeRef<CryptoSymbol>,
-  transaction: Ref<CoinTransaction | undefined>
+  transaction: Ref<CoinTransaction | undefined>,
+  transactionStatus?: MaybeRef<TransactionStatusType | undefined>
 ) {
   const store = useStore()
+  const resolvedStatus = computed(() => unref(transactionStatus) ?? transaction.value?.status)
 
   watch(
-    transaction,
-    (transaction) => {
+    resolvedStatus,
+    (status, previousStatus) => {
       const cryptoSymbol = unref(crypto)
       const cryptoModule = cryptoSymbol.toLowerCase()
+      const currentTransaction = transaction.value
 
       const pendingTransaction = PendingTxStore.get(cryptoSymbol)
-      const isPendingTransaction = pendingTransaction?.id === transaction?.id
+      const isPendingTransaction = pendingTransaction?.id === currentTransaction?.id
+      const hasStatusChanged = status !== previousStatus
+      const shouldRefreshStore =
+        status === TransactionStatus.REGISTERED ||
+        status === TransactionStatus.CONFIRMED ||
+        status === TransactionStatus.REJECTED
       const isFinalized =
-        transaction?.status === TransactionStatus.CONFIRMED ||
-        transaction?.status === TransactionStatus.REJECTED
+        status === TransactionStatus.CONFIRMED || status === TransactionStatus.REJECTED
 
-      if (isPendingTransaction && isFinalized) {
-        PendingTxStore.remove(cryptoSymbol)
-        store.dispatch(`${cryptoModule}/getNewTransactions`)
+      if (!isPendingTransaction || !status || !hasStatusChanged || !shouldRefreshStore) {
+        return
       }
+
+      if (isFinalized) {
+        PendingTxStore.remove(cryptoSymbol)
+      }
+
+      void store.dispatch(`${cryptoModule}/getNewTransactions`)
     },
     {
       immediate: true

--- a/src/components/transactions/hooks/useFindAdmAddress.ts
+++ b/src/components/transactions/hooks/useFindAdmAddress.ts
@@ -26,7 +26,7 @@ export function useFindAdmAddress(
     const transactionHashValue = unref(transactionHash)
 
     // First, check the known partners
-    const partners = store.state.partners
+    const partners = store.state.partners?.list || {}
     Object.keys(partners).some((uid) => {
       const partner = partners[uid]
       if (isStringEqualCI(partner[crypto.value], cryptoAddressValue)) {

--- a/src/components/transactions/hooks/useFindAdmTransaction.ts
+++ b/src/components/transactions/hooks/useFindAdmTransaction.ts
@@ -1,6 +1,6 @@
 import { computed, ComputedRef, MaybeRef, unref } from 'vue'
 import { useStore } from 'vuex'
-import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 
 /**
  * Find ADM special message by transactionHash in the chat messages

--- a/src/components/transactions/hooks/useFindAdmTransaction.ts
+++ b/src/components/transactions/hooks/useFindAdmTransaction.ts
@@ -19,7 +19,7 @@ export function useFindAdmTransaction(
       // @ts-expect-error-next-line
       Object.values(chat.messages).some((msg) => {
         // @ts-expect-error-next-line
-        if (msg.hash && msg.hash === hashValue) {
+        if ((msg.hash && msg.hash === hashValue) || msg.id === hashValue) {
           admTx = msg as NormalizedChatMessageTransaction
         }
         return !!admTx?.id

--- a/src/components/transactions/hooks/useFindAdmTransaction.ts
+++ b/src/components/transactions/hooks/useFindAdmTransaction.ts
@@ -6,24 +6,42 @@ import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normal
  * Find ADM special message by transactionHash in the chat messages
  */
 export function useFindAdmTransaction(
-  hash: MaybeRef<string | undefined>
+  hash: MaybeRef<string | undefined>,
+  preferredPartnerId?: MaybeRef<string | undefined>
 ): ComputedRef<NormalizedChatMessageTransaction | undefined> {
   const store = useStore()
 
   return computed(() => {
     const hashValue = unref(hash)
+    const preferredPartnerIdValue = unref(preferredPartnerId)
 
     let admTx: NormalizedChatMessageTransaction | undefined
-    // Bad news, everyone: we'll have to scan the messages
-    Object.values(store.state.chat.chats).some((chat) => {
-      // @ts-expect-error-next-line
-      Object.values(chat.messages).some((msg) => {
-        // @ts-expect-error-next-line
+    const findInMessages = (messages: Record<string, any>[] | undefined) => {
+      return messages?.some((msg) => {
         if ((msg.hash && msg.hash === hashValue) || msg.id === hashValue) {
           admTx = msg as NormalizedChatMessageTransaction
         }
+
         return !!admTx?.id
       })
+    }
+
+    if (preferredPartnerIdValue) {
+      const preferredMessages = store.state.chat.chats[preferredPartnerIdValue]?.messages as
+        | Record<string, any>[]
+        | undefined
+
+      findInMessages(preferredMessages)
+    }
+
+    if (admTx?.id) {
+      return admTx
+    }
+
+    // Bad news, everyone: we'll have to scan the messages
+    Object.values(store.state.chat.chats).some((chat) => {
+      // @ts-expect-error-next-line
+      findInMessages(Object.values(chat.messages))
       return !!admTx?.id
     })
     return admTx

--- a/src/components/transactions/hooks/useInconsistentStatus.spec.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.spec.ts
@@ -1,0 +1,96 @@
+import { computed, ref } from 'vue'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Cryptos, TransactionStatus } from '@/lib/constants'
+import { TransactionInconsistentReason } from '../utils/getInconsistentStatus'
+
+const admTransaction = ref<any>()
+const senderCryptoAddress = ref<string | undefined>()
+const recipientCryptoAddress = ref<string | undefined>()
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    state: {
+      btc: { address: 'my-btc-address' },
+      eth: { address: 'my-eth-address' }
+    }
+  })
+}))
+
+vi.mock('./useFindAdmTransaction', () => ({
+  useFindAdmTransaction: () => computed(() => admTransaction.value)
+}))
+
+vi.mock('@/hooks/queries/useKVSCryptoAddress', () => ({
+  useKVSCryptoAddress: (admAddress: { value?: string }) =>
+    computed(() =>
+      admAddress.value === admTransaction.value?.senderId
+        ? senderCryptoAddress.value
+        : recipientCryptoAddress.value
+    )
+}))
+
+import { useInconsistentStatus } from './useInconsistentStatus'
+
+describe('useInconsistentStatus', () => {
+  beforeEach(() => {
+    admTransaction.value = {
+      id: 'adm-1',
+      hash: 'tx-1',
+      senderId: 'sender-adm',
+      recipientId: 'recipient-adm',
+      amount: 1,
+      timestamp: Date.now(),
+      confirmations: 0,
+      status: TransactionStatus.PENDING,
+      type: Cryptos.BTC,
+      message: '',
+      asset: {}
+    }
+    senderCryptoAddress.value = 'chain-sender'
+    recipientCryptoAddress.value = 'chain-recipient'
+  })
+
+  it('reports missing recipient KVS address as an inconsistent status', () => {
+    recipientCryptoAddress.value = undefined
+
+    const result = useInconsistentStatus(
+      ref({
+        id: 'tx-1',
+        hash: 'tx-1',
+        fee: 0,
+        status: TransactionStatus.CONFIRMED,
+        timestamp: Date.now(),
+        direction: 'from',
+        senderId: 'chain-sender',
+        recipientId: 'chain-recipient',
+        amount: 1,
+        confirmations: 1
+      }) as any,
+      Cryptos.BTC
+    )
+
+    expect(result.value).toBe(TransactionInconsistentReason.NO_RECIPIENT_CRYPTO_ADDRESS)
+  })
+
+  it('reports missing sender KVS address as an inconsistent status', () => {
+    senderCryptoAddress.value = undefined
+
+    const result = useInconsistentStatus(
+      ref({
+        id: 'tx-1',
+        hash: 'tx-1',
+        fee: 0,
+        status: TransactionStatus.CONFIRMED,
+        timestamp: Date.now(),
+        direction: 'from',
+        senderId: 'chain-sender',
+        recipientId: 'chain-recipient',
+        amount: 1,
+        confirmations: 1
+      }) as any,
+      Cryptos.BTC
+    )
+
+    expect(result.value).toBe(TransactionInconsistentReason.NO_SENDER_CRYPTO_ADDRESS)
+  })
+})

--- a/src/components/transactions/hooks/useInconsistentStatus.spec.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.spec.ts
@@ -6,6 +6,8 @@ import { TransactionInconsistentReason } from '../utils/getInconsistentStatus'
 const admTransaction = ref<any>()
 const senderCryptoAddress = ref<string | undefined>()
 const recipientCryptoAddress = ref<string | undefined>()
+const senderCryptoAddressStatus = ref<'pending' | 'success' | 'error'>('success')
+const recipientCryptoAddressStatus = ref<'pending' | 'success' | 'error'>('success')
 
 vi.mock('vuex', () => ({
   useStore: () => ({
@@ -21,12 +23,18 @@ vi.mock('./useFindAdmTransaction', () => ({
 }))
 
 vi.mock('@/hooks/queries/useKVSCryptoAddress', () => ({
-  useKVSCryptoAddress: (admAddress: { value?: string }) =>
-    computed(() =>
+  useKVSCryptoAddress: (admAddress: { value?: string }) => ({
+    data: computed(() =>
       admAddress.value === admTransaction.value?.senderId
         ? senderCryptoAddress.value
         : recipientCryptoAddress.value
+    ),
+    status: computed(() =>
+      admAddress.value === admTransaction.value?.senderId
+        ? senderCryptoAddressStatus.value
+        : recipientCryptoAddressStatus.value
     )
+  })
 }))
 
 import { useInconsistentStatus } from './useInconsistentStatus'
@@ -48,6 +56,8 @@ describe('useInconsistentStatus', () => {
     }
     senderCryptoAddress.value = 'chain-sender'
     recipientCryptoAddress.value = 'chain-recipient'
+    senderCryptoAddressStatus.value = 'success'
+    recipientCryptoAddressStatus.value = 'success'
   })
 
   it('reports missing recipient KVS address as an inconsistent status', () => {
@@ -107,6 +117,29 @@ describe('useInconsistentStatus', () => {
         recipientId: 'wrong-recipient',
         amount: 999,
         confirmations: 0
+      }) as any,
+      Cryptos.BTC
+    )
+
+    expect(result.value).toBe('')
+  })
+
+  it('waits for KVS address lookups before marking a transaction as inconsistent', () => {
+    recipientCryptoAddress.value = undefined
+    recipientCryptoAddressStatus.value = 'pending'
+
+    const result = useInconsistentStatus(
+      ref({
+        id: 'tx-1',
+        hash: 'tx-1',
+        fee: 0,
+        status: TransactionStatus.CONFIRMED,
+        timestamp: Date.now(),
+        direction: 'from',
+        senderId: 'chain-sender',
+        recipientId: 'chain-recipient',
+        amount: 1,
+        confirmations: 1
       }) as any,
       Cryptos.BTC
     )

--- a/src/components/transactions/hooks/useInconsistentStatus.spec.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.spec.ts
@@ -93,4 +93,24 @@ describe('useInconsistentStatus', () => {
 
     expect(result.value).toBe(TransactionInconsistentReason.NO_SENDER_CRYPTO_ADDRESS)
   })
+
+  it('does not mark locally pending placeholder transactions as inconsistent', () => {
+    const result = useInconsistentStatus(
+      ref({
+        id: 'tx-1',
+        hash: 'tx-1',
+        fee: 0,
+        status: TransactionStatus.PENDING,
+        timestamp: Date.now(),
+        direction: 'from',
+        senderId: 'wrong-sender',
+        recipientId: 'wrong-recipient',
+        amount: 999,
+        confirmations: 0
+      }) as any,
+      Cryptos.BTC
+    )
+
+    expect(result.value).toBe('')
+  })
 })

--- a/src/components/transactions/hooks/useInconsistentStatus.spec.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.spec.ts
@@ -113,4 +113,75 @@ describe('useInconsistentStatus', () => {
 
     expect(result.value).toBe('')
   })
+
+  it('never marks native ADM transactions as inconsistent', () => {
+    recipientCryptoAddress.value = undefined
+    senderCryptoAddress.value = undefined
+
+    const result = useInconsistentStatus(
+      ref({
+        id: 'tx-1',
+        fee: 0.5,
+        amount: 1,
+        senderId: 'sender-adm',
+        recipientId: 'recipient-adm',
+        message: 'hello',
+        status: TransactionStatus.CONFIRMED,
+        timestamp: Date.now()
+      }) as any,
+      Cryptos.ADM
+    )
+
+    expect(result.value).toBe('')
+  })
+
+  it('prefers the explicitly provided ADM transaction over a global hash match', () => {
+    admTransaction.value = {
+      id: 'wrong-adm',
+      hash: 'tx-1',
+      senderId: 'sender-adm',
+      recipientId: 'recipient-adm',
+      amount: 999,
+      timestamp: Date.now(),
+      confirmations: 1,
+      status: TransactionStatus.CONFIRMED,
+      type: Cryptos.BTC,
+      message: '',
+      asset: {}
+    }
+
+    const result = useInconsistentStatus(
+      ref({
+        id: 'tx-1',
+        hash: 'tx-1',
+        fee: 0,
+        status: TransactionStatus.CONFIRMED,
+        timestamp: Date.now(),
+        direction: 'from',
+        senderId: 'chain-sender',
+        recipientId: 'chain-recipient',
+        amount: 1,
+        confirmations: 1
+      }) as any,
+      Cryptos.BTC,
+      computed(
+        () =>
+          ({
+            id: 'right-adm',
+            hash: 'tx-1',
+            senderId: 'sender-adm',
+            recipientId: 'recipient-adm',
+            amount: 1,
+            timestamp: Date.now(),
+            confirmations: 1,
+            status: TransactionStatus.CONFIRMED,
+            type: Cryptos.BTC,
+            message: '',
+            asset: {}
+          }) as any
+      )
+    )
+
+    expect(result.value).toBe('')
+  })
 })

--- a/src/components/transactions/hooks/useInconsistentStatus.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.ts
@@ -47,6 +47,10 @@ export function useInconsistentStatus(
       return ''
     }
 
+    if ('status' in transaction.value && transaction.value.status === 'PENDING') {
+      return ''
+    }
+
     return getInconsistentStatus(transaction.value, admTx.value, {
       senderCryptoAddress: senderCryptoAddress.value,
       recipientCryptoAddress: recipientCryptoAddress.value

--- a/src/components/transactions/hooks/useInconsistentStatus.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.ts
@@ -29,6 +29,23 @@ export function useInconsistentStatus(
   crypto: CryptoSymbol,
   knownAdmTransaction?: MaybeRef<NormalizedChatMessageTransaction | undefined>
 ) {
+  return useInconsistentStatusState(transaction, crypto, knownAdmTransaction).status
+}
+
+export function useInconsistentStatusState(
+  transaction: Ref<
+    | BtcTransaction
+    | DogeTransaction
+    | DashTransaction
+    | EthTransaction
+    | Erc20Transaction
+    | PendingTransaction
+    | DecodedChatMessageTransaction
+    | undefined
+  >,
+  crypto: CryptoSymbol,
+  knownAdmTransaction?: MaybeRef<NormalizedChatMessageTransaction | undefined>
+) {
   const store = useStore()
   const isAdmCrypto = crypto === Cryptos.ADM
 
@@ -45,16 +62,47 @@ export function useInconsistentStatus(
   const admTx = computed(() => unref(knownAdmTransaction) || foundAdmTx.value)
   const senderId = computed(() => admTx.value?.senderId)
   const recipientId = computed(() => admTx.value?.recipientId)
-  const senderCryptoAddress = useKVSCryptoAddress(senderId, crypto)
-  const recipientCryptoAddress = useKVSCryptoAddress(recipientId, crypto)
+  const senderCryptoAddressQuery = useKVSCryptoAddress(senderId, crypto)
+  const recipientCryptoAddressQuery = useKVSCryptoAddress(recipientId, crypto)
+  const senderCryptoAddress = computed(() => senderCryptoAddressQuery.data.value)
+  const recipientCryptoAddress = computed(() => recipientCryptoAddressQuery.data.value)
   const isSenderOwnAddress = computed(
     () => !!admTx.value?.senderId && admTx.value.senderId === store.state.address
   )
   const isRecipientOwnAddress = computed(
     () => !!admTx.value?.recipientId && admTx.value.recipientId === store.state.address
   )
+  const isSenderCryptoAddressResolved = computed(() => {
+    if (isSenderOwnAddress.value || !senderId.value) {
+      return true
+    }
 
-  return computed<InconsistentStatus>(() => {
+    return senderCryptoAddressQuery.status.value === 'success'
+  })
+  const isRecipientCryptoAddressResolved = computed(() => {
+    if (isRecipientOwnAddress.value || !recipientId.value) {
+      return true
+    }
+
+    return recipientCryptoAddressQuery.status.value === 'success'
+  })
+  const isResolving = computed(() => {
+    if (isAdmCrypto) {
+      return false
+    }
+
+    if (!transaction.value || !admTx.value || !mineCryptoAddress.value) {
+      return false
+    }
+
+    if ('status' in transaction.value && transaction.value.status === 'PENDING') {
+      return false
+    }
+
+    return !isSenderCryptoAddressResolved.value || !isRecipientCryptoAddressResolved.value
+  })
+
+  const status = computed<InconsistentStatus>(() => {
     if (isAdmCrypto) {
       return ''
     }
@@ -64,6 +112,10 @@ export function useInconsistentStatus(
     }
 
     if ('status' in transaction.value && transaction.value.status === 'PENDING') {
+      return ''
+    }
+
+    if (isResolving.value) {
       return ''
     }
 
@@ -78,4 +130,9 @@ export function useInconsistentStatus(
       recipientCryptoAddress: resolvedRecipientCryptoAddress
     })
   })
+
+  return {
+    status,
+    isResolving
+  }
 }

--- a/src/components/transactions/hooks/useInconsistentStatus.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.ts
@@ -1,9 +1,10 @@
-import { computed, Ref } from 'vue'
+import { computed, MaybeRef, Ref, unref } from 'vue'
 import { useStore } from 'vuex'
 import { useFindAdmTransaction } from './useFindAdmTransaction'
 import { useKVSCryptoAddress } from '@/hooks/queries/useKVSCryptoAddress'
-import { CryptoSymbol, isErc20 } from '@/lib/constants'
+import { Cryptos, CryptoSymbol, isErc20 } from '@/lib/constants'
 import type { DecodedChatMessageTransaction } from '@/lib/adamant-api'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 import { getInconsistentStatus, InconsistentStatus } from '../utils/getInconsistentStatus'
 import {
   BtcTransaction,
@@ -25,24 +26,39 @@ export function useInconsistentStatus(
     | DecodedChatMessageTransaction
     | undefined
   >,
-  crypto: CryptoSymbol
+  crypto: CryptoSymbol,
+  knownAdmTransaction?: MaybeRef<NormalizedChatMessageTransaction | undefined>
 ) {
   const store = useStore()
+  const isAdmCrypto = crypto === Cryptos.ADM
 
   const mineCryptoAddress = computed(() => {
+    if (isAdmCrypto) return store.state.address
+
     if (isErc20(crypto)) return store.state.eth.address
 
     return store.state[crypto.toLowerCase()].address
   })
   const transactionId = computed(() => transaction.value?.id)
 
-  const admTx = useFindAdmTransaction(transactionId)
+  const foundAdmTx = useFindAdmTransaction(transactionId)
+  const admTx = computed(() => unref(knownAdmTransaction) || foundAdmTx.value)
   const senderId = computed(() => admTx.value?.senderId)
   const recipientId = computed(() => admTx.value?.recipientId)
   const senderCryptoAddress = useKVSCryptoAddress(senderId, crypto)
   const recipientCryptoAddress = useKVSCryptoAddress(recipientId, crypto)
+  const isSenderOwnAddress = computed(
+    () => !!admTx.value?.senderId && admTx.value.senderId === store.state.address
+  )
+  const isRecipientOwnAddress = computed(
+    () => !!admTx.value?.recipientId && admTx.value.recipientId === store.state.address
+  )
 
   return computed<InconsistentStatus>(() => {
+    if (isAdmCrypto) {
+      return ''
+    }
+
     if (!transaction.value || !admTx.value || !mineCryptoAddress.value) {
       return ''
     }
@@ -51,9 +67,15 @@ export function useInconsistentStatus(
       return ''
     }
 
+    const resolvedSenderCryptoAddress =
+      senderCryptoAddress.value || (isSenderOwnAddress.value ? mineCryptoAddress.value : undefined)
+    const resolvedRecipientCryptoAddress =
+      recipientCryptoAddress.value ||
+      (isRecipientOwnAddress.value ? mineCryptoAddress.value : undefined)
+
     return getInconsistentStatus(transaction.value, admTx.value, {
-      senderCryptoAddress: senderCryptoAddress.value,
-      recipientCryptoAddress: recipientCryptoAddress.value
+      senderCryptoAddress: resolvedSenderCryptoAddress,
+      recipientCryptoAddress: resolvedRecipientCryptoAddress
     })
   })
 }

--- a/src/components/transactions/hooks/useInconsistentStatus.ts
+++ b/src/components/transactions/hooks/useInconsistentStatus.ts
@@ -3,7 +3,7 @@ import { useStore } from 'vuex'
 import { useFindAdmTransaction } from './useFindAdmTransaction'
 import { useKVSCryptoAddress } from '@/hooks/queries/useKVSCryptoAddress'
 import { CryptoSymbol, isErc20 } from '@/lib/constants'
-import { DecodedChatMessageTransaction } from '@/lib/adamant-api'
+import type { DecodedChatMessageTransaction } from '@/lib/adamant-api'
 import { getInconsistentStatus, InconsistentStatus } from '../utils/getInconsistentStatus'
 import {
   BtcTransaction,
@@ -43,14 +43,9 @@ export function useInconsistentStatus(
   const recipientCryptoAddress = useKVSCryptoAddress(recipientId, crypto)
 
   return computed<InconsistentStatus>(() => {
-    if (
-      !transaction.value ||
-      !admTx.value ||
-      !mineCryptoAddress.value ||
-      !senderCryptoAddress.value ||
-      !recipientCryptoAddress.value
-    )
+    if (!transaction.value || !admTx.value || !mineCryptoAddress.value) {
       return ''
+    }
 
     return getInconsistentStatus(transaction.value, admTx.value, {
       senderCryptoAddress: senderCryptoAddress.value,

--- a/src/components/transactions/hooks/useSyncChatTransferPendingStatus.spec.ts
+++ b/src/components/transactions/hooks/useSyncChatTransferPendingStatus.spec.ts
@@ -1,0 +1,94 @@
+import { defineComponent, PropType, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
+import { describe, expect, it, vi } from 'vitest'
+import { TransactionStatus } from '@/lib/constants'
+import {
+  hasTransactionFinalStatusInSession,
+  makeTransactionStatusSessionKey,
+  rememberTransactionFinalStatus,
+  resetTransactionStatusSessionCache,
+  syncTransactionStatusSession
+} from '@/providers/TransactionProvider/sessionFinalStatusCache'
+import { useSyncChatTransferPendingStatus } from './useSyncChatTransferPendingStatus'
+
+const queryStatus = ref<'pending' | 'success'>('success')
+const isFetching = ref(false)
+
+const HookHost = defineComponent({
+  props: {
+    transaction: {
+      type: Object as PropType<Record<string, any> | undefined>,
+      default: undefined
+    }
+  },
+  setup(props) {
+    useSyncChatTransferPendingStatus(
+      'DOGE',
+      'doge-hash',
+      ref(props.transaction as any),
+      isFetching,
+      queryStatus as any
+    )
+
+    return () => null
+  }
+})
+
+describe('useSyncChatTransferPendingStatus', () => {
+  it('pushes a final chat transfer back to pending when details start a new status check', () => {
+    resetTransactionStatusSessionCache()
+    syncTransactionStatusSession('U111111')
+
+    const store = createStore({
+      state: {
+        address: 'U111111'
+      },
+      modules: {
+        chat: {
+          namespaced: true,
+          mutations: {
+            updateCryptoTransferMessage() {}
+          }
+        }
+      }
+    })
+    const commit = vi.spyOn(store, 'commit')
+
+    rememberTransactionFinalStatus(
+      makeTransactionStatusSessionKey('U111111', 'DOGE', 'doge-hash'),
+      TransactionStatus.REJECTED
+    )
+
+    queryStatus.value = 'pending'
+    isFetching.value = true
+
+    mount(HookHost, {
+      props: {
+        transaction: {
+          id: 'adm-msg-id',
+          hash: 'doge-hash',
+          type: 'DOGE',
+          senderId: 'U111111',
+          recipientId: 'U222222',
+          status: TransactionStatus.REJECTED
+        }
+      },
+      global: {
+        plugins: [store]
+      }
+    })
+
+    expect(commit).toHaveBeenCalledWith('chat/updateCryptoTransferMessage', {
+      partnerId: 'U222222',
+      hash: 'doge-hash',
+      status: TransactionStatus.PENDING
+    })
+    expect(
+      hasTransactionFinalStatusInSession(
+        makeTransactionStatusSessionKey('U111111', 'DOGE', 'doge-hash'),
+        TransactionStatus.REJECTED
+      )
+    ).toBe(false)
+  })
+})

--- a/src/components/transactions/hooks/useSyncChatTransferPendingStatus.ts
+++ b/src/components/transactions/hooks/useSyncChatTransferPendingStatus.ts
@@ -1,0 +1,79 @@
+import type { QueryStatus } from '@tanstack/vue-query'
+import { computed, MaybeRef, Ref, unref, watch } from 'vue'
+import { useStore } from 'vuex'
+import { CryptoSymbol, TransactionStatus, TransactionStatusType } from '@/lib/constants'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
+import { getPartnerAddress } from '../utils/getPartnerAddress'
+import {
+  forgetTransactionFinalStatus,
+  makeTransactionStatusSessionKey
+} from '@/providers/TransactionProvider/sessionFinalStatusCache'
+
+const FINAL_TRANSACTION_STATUSES = new Set<TransactionStatusType>([
+  TransactionStatus.CONFIRMED,
+  TransactionStatus.REJECTED,
+  TransactionStatus.INVALID
+])
+
+export function useSyncChatTransferPendingStatus(
+  crypto: MaybeRef<CryptoSymbol>,
+  transactionId: MaybeRef<string>,
+  chatTransaction: Ref<NormalizedChatMessageTransaction | undefined>,
+  isFetching: Ref<boolean>,
+  queryStatus?: Ref<QueryStatus>
+) {
+  const store = useStore()
+
+  const partnerId = computed(() => {
+    const localChatTransaction = chatTransaction.value
+
+    if (!localChatTransaction) {
+      return ''
+    }
+
+    return getPartnerAddress(
+      localChatTransaction.senderId,
+      localChatTransaction.recipientId,
+      store.state.address
+    )
+  })
+
+  const syncPendingStatus = () => {
+    const localChatTransaction = chatTransaction.value
+    const transactionKey = makeTransactionStatusSessionKey(
+      store.state.address,
+      unref(crypto),
+      unref(transactionId)
+    )
+
+    if (
+      !localChatTransaction ||
+      !partnerId.value ||
+      !FINAL_TRANSACTION_STATUSES.has(localChatTransaction.status)
+    ) {
+      return
+    }
+
+    forgetTransactionFinalStatus(transactionKey)
+
+    store.commit('chat/updateCryptoTransferMessage', {
+      partnerId: partnerId.value,
+      hash: localChatTransaction.hash || localChatTransaction.id,
+      status: TransactionStatus.PENDING
+    })
+  }
+
+  watch(
+    () => (queryStatus ? queryStatus.value === 'pending' || isFetching.value : isFetching.value),
+    (shouldSyncPending) => {
+      if (shouldSyncPending) {
+        syncPendingStatus()
+      }
+    },
+    { immediate: true }
+  )
+
+  return {
+    syncPendingStatus
+  }
+}

--- a/src/components/transactions/hooks/useTransactionAdditionalStatus.spec.ts
+++ b/src/components/transactions/hooks/useTransactionAdditionalStatus.spec.ts
@@ -1,0 +1,40 @@
+import { ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { Cryptos, TransactionAdditionalStatus, TransactionStatus } from '@/lib/constants'
+import { useTransactionAdditionalStatus } from './useTransactionAdditionalStatus'
+
+describe('useTransactionAdditionalStatus', () => {
+  it('marks Dash registered InstantSend transactions with an additional status', () => {
+    const additionalStatus = useTransactionAdditionalStatus(
+      ref({
+        status: TransactionStatus.REGISTERED,
+        instantsend: true
+      }),
+      Cryptos.DASH
+    )
+
+    expect(additionalStatus.value).toBe(TransactionAdditionalStatus.INSTANT_SEND)
+  })
+
+  it('marks registered ADM transactions with an additional status', () => {
+    const additionalStatus = useTransactionAdditionalStatus(
+      ref({
+        status: TransactionStatus.REGISTERED
+      }),
+      Cryptos.ADM
+    )
+
+    expect(additionalStatus.value).toBe(TransactionAdditionalStatus.ADM_REGISTERED)
+  })
+
+  it('does not add a special status for regular registered DOGE transactions', () => {
+    const additionalStatus = useTransactionAdditionalStatus(
+      ref({
+        status: TransactionStatus.REGISTERED
+      }),
+      Cryptos.DOGE
+    )
+
+    expect(additionalStatus.value).toBe(TransactionAdditionalStatus.NONE)
+  })
+})

--- a/src/components/transactions/hooks/useTransactionAdditionalStatus.ts
+++ b/src/components/transactions/hooks/useTransactionAdditionalStatus.ts
@@ -1,0 +1,47 @@
+import { computed, MaybeRef, Ref, unref } from 'vue'
+import {
+  Cryptos,
+  CryptoSymbol,
+  TransactionAdditionalStatus,
+  TransactionAdditionalStatusType,
+  TransactionStatus
+} from '@/lib/constants'
+
+type TransactionWithAdditionalStatus = {
+  status?: string
+  instantlock?: boolean
+  instantlock_internal?: boolean
+  instantsend?: boolean
+}
+
+export function useTransactionAdditionalStatus(
+  transaction: Ref<any>,
+  crypto: MaybeRef<CryptoSymbol>
+) {
+  return computed<TransactionAdditionalStatusType>(() => {
+    const currentTransaction = transaction.value as TransactionWithAdditionalStatus | undefined
+
+    if (!currentTransaction?.status) {
+      return TransactionAdditionalStatus.NONE
+    }
+
+    if (
+      unref(crypto) === Cryptos.DASH &&
+      currentTransaction.status === TransactionStatus.REGISTERED &&
+      (currentTransaction.instantsend ||
+        currentTransaction.instantlock ||
+        currentTransaction.instantlock_internal)
+    ) {
+      return TransactionAdditionalStatus.INSTANT_SEND
+    }
+
+    if (
+      unref(crypto) === Cryptos.ADM &&
+      currentTransaction.status === TransactionStatus.REGISTERED
+    ) {
+      return TransactionAdditionalStatus.ADM_REGISTERED
+    }
+
+    return TransactionAdditionalStatus.NONE
+  })
+}

--- a/src/components/transactions/hooks/useTransactionStatus.spec.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.spec.ts
@@ -1,6 +1,6 @@
 import { computed, ref } from 'vue'
 import { describe, expect, it } from 'vitest'
-import { TransactionStatus } from '@/lib/constants'
+import { TransactionAdditionalStatus, TransactionStatus } from '@/lib/constants'
 import { useTransactionStatus } from './useTransactionStatus'
 
 describe('useTransactionStatus', () => {
@@ -18,5 +18,29 @@ describe('useTransactionStatus', () => {
     const status = useTransactionStatus(ref(false), ref('error'))
 
     expect(status.value).toBe(TransactionStatus.REJECTED)
+  })
+
+  it('treats Dash InstantSend as a successful virtual status', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('success'),
+      computed(() => TransactionStatus.REGISTERED),
+      undefined,
+      computed(() => TransactionAdditionalStatus.INSTANT_SEND)
+    )
+
+    expect(status.value).toBe(TransactionStatus.CONFIRMED)
+  })
+
+  it('keeps Dash InstantSend as successful even if a follow-up fetch errors', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      computed(() => TransactionStatus.REGISTERED),
+      undefined,
+      computed(() => TransactionAdditionalStatus.INSTANT_SEND)
+    )
+
+    expect(status.value).toBe(TransactionStatus.CONFIRMED)
   })
 })

--- a/src/components/transactions/hooks/useTransactionStatus.spec.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.spec.ts
@@ -1,0 +1,22 @@
+import { computed, ref } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { TransactionStatus } from '@/lib/constants'
+import { useTransactionStatus } from './useTransactionStatus'
+
+describe('useTransactionStatus', () => {
+  it('keeps optimistic pending status when a live query errors before the transaction is indexed', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      computed(() => TransactionStatus.PENDING)
+    )
+
+    expect(status.value).toBe(TransactionStatus.PENDING)
+  })
+
+  it('falls back to rejected when a live query errors and there is no known transaction state', () => {
+    const status = useTransactionStatus(ref(false), ref('error'))
+
+    expect(status.value).toBe(TransactionStatus.REJECTED)
+  })
+})

--- a/src/components/transactions/hooks/useTransactionStatus.spec.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.spec.ts
@@ -4,6 +4,8 @@ import { TransactionAdditionalStatus, TransactionStatus } from '@/lib/constants'
 import { AllNodesOfflineError } from '@/lib/nodes/utils/errors'
 import { useTransactionStatus } from './useTransactionStatus'
 
+const boolRef = (value: boolean) => ref<boolean | undefined>(value)
+
 describe('useTransactionStatus', () => {
   it('rejects a pending status when a background refetch exhausts all retries', () => {
     const status = useTransactionStatus(
@@ -12,8 +14,9 @@ describe('useTransactionStatus', () => {
       computed(() => TransactionStatus.PENDING),
       undefined,
       undefined,
-      ref(false),
-      ref(true)
+      undefined,
+      boolRef(false),
+      boolRef(true)
     )
 
     expect(status.value).toBe(TransactionStatus.REJECTED)
@@ -26,8 +29,9 @@ describe('useTransactionStatus', () => {
       computed(() => TransactionStatus.REGISTERED),
       undefined,
       undefined,
-      ref(false),
-      ref(true)
+      undefined,
+      boolRef(false),
+      boolRef(true)
     )
 
     expect(status.value).toBe(TransactionStatus.REGISTERED)
@@ -40,8 +44,9 @@ describe('useTransactionStatus', () => {
       undefined,
       undefined,
       undefined,
-      ref(true),
-      ref(false)
+      undefined,
+      boolRef(true),
+      boolRef(false)
     )
 
     expect(status.value).toBe(TransactionStatus.REJECTED)
@@ -54,8 +59,9 @@ describe('useTransactionStatus', () => {
       undefined,
       undefined,
       undefined,
-      ref(true),
-      ref(false),
+      undefined,
+      boolRef(true),
+      boolRef(false),
       ref(new AllNodesOfflineError('btc'))
     )
 
@@ -69,8 +75,9 @@ describe('useTransactionStatus', () => {
       computed(() => TransactionStatus.PENDING),
       undefined,
       undefined,
-      ref(true),
-      ref(false)
+      undefined,
+      boolRef(true),
+      boolRef(false)
     )
 
     expect(status.value).toBe(TransactionStatus.REJECTED)
@@ -83,8 +90,9 @@ describe('useTransactionStatus', () => {
       computed(() => TransactionStatus.PENDING),
       undefined,
       undefined,
-      ref(false),
-      ref(false)
+      undefined,
+      boolRef(false),
+      boolRef(false)
     )
 
     expect(status.value).toBe(TransactionStatus.REJECTED)
@@ -95,6 +103,7 @@ describe('useTransactionStatus', () => {
       ref(false),
       ref('success'),
       computed(() => TransactionStatus.REGISTERED),
+      undefined,
       undefined,
       computed(() => TransactionAdditionalStatus.INSTANT_SEND)
     )
@@ -108,11 +117,25 @@ describe('useTransactionStatus', () => {
       ref('error'),
       computed(() => TransactionStatus.REGISTERED),
       undefined,
+      undefined,
       computed(() => TransactionAdditionalStatus.INSTANT_SEND),
-      ref(false),
-      ref(true)
+      boolRef(false),
+      boolRef(true)
     )
 
     expect(status.value).toBe(TransactionStatus.CONFIRMED)
+  })
+
+  it('keeps a transfer pending while consistency checks are still resolving', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('success'),
+      computed(() => TransactionStatus.CONFIRMED),
+      computed(() => ''),
+      computed(() => true),
+      computed(() => TransactionAdditionalStatus.NONE)
+    )
+
+    expect(status.value).toBe(TransactionStatus.PENDING)
   })
 })

--- a/src/components/transactions/hooks/useTransactionStatus.spec.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.spec.ts
@@ -4,18 +4,58 @@ import { TransactionAdditionalStatus, TransactionStatus } from '@/lib/constants'
 import { useTransactionStatus } from './useTransactionStatus'
 
 describe('useTransactionStatus', () => {
-  it('keeps optimistic pending status when a live query errors before the transaction is indexed', () => {
+  it('rejects a pending status when a background refetch exhausts all retries', () => {
     const status = useTransactionStatus(
       ref(false),
       ref('error'),
-      computed(() => TransactionStatus.PENDING)
+      computed(() => TransactionStatus.PENDING),
+      undefined,
+      undefined,
+      ref(false),
+      ref(true)
     )
 
-    expect(status.value).toBe(TransactionStatus.PENDING)
+    expect(status.value).toBe(TransactionStatus.REJECTED)
+  })
+
+  it('keeps a registered status when a background refetch errors after the node has seen the transaction', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      computed(() => TransactionStatus.REGISTERED),
+      undefined,
+      undefined,
+      ref(false),
+      ref(true)
+    )
+
+    expect(status.value).toBe(TransactionStatus.REGISTERED)
   })
 
   it('falls back to rejected when a live query errors and there is no known transaction state', () => {
-    const status = useTransactionStatus(ref(false), ref('error'))
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      undefined,
+      undefined,
+      undefined,
+      ref(true),
+      ref(false)
+    )
+
+    expect(status.value).toBe(TransactionStatus.REJECTED)
+  })
+
+  it('rejects a pending transaction when the initial lookup exhausts all retries', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      computed(() => TransactionStatus.PENDING),
+      undefined,
+      undefined,
+      ref(true),
+      ref(false)
+    )
 
     expect(status.value).toBe(TransactionStatus.REJECTED)
   })
@@ -38,7 +78,9 @@ describe('useTransactionStatus', () => {
       ref('error'),
       computed(() => TransactionStatus.REGISTERED),
       undefined,
-      computed(() => TransactionAdditionalStatus.INSTANT_SEND)
+      computed(() => TransactionAdditionalStatus.INSTANT_SEND),
+      ref(false),
+      ref(true)
     )
 
     expect(status.value).toBe(TransactionStatus.CONFIRMED)

--- a/src/components/transactions/hooks/useTransactionStatus.spec.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.spec.ts
@@ -1,6 +1,7 @@
 import { computed, ref } from 'vue'
 import { describe, expect, it } from 'vitest'
 import { TransactionAdditionalStatus, TransactionStatus } from '@/lib/constants'
+import { AllNodesOfflineError } from '@/lib/nodes/utils/errors'
 import { useTransactionStatus } from './useTransactionStatus'
 
 describe('useTransactionStatus', () => {
@@ -46,6 +47,21 @@ describe('useTransactionStatus', () => {
     expect(status.value).toBe(TransactionStatus.REJECTED)
   })
 
+  it('keeps pending while the query error is recoverable and the network can come back later', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      undefined,
+      undefined,
+      undefined,
+      ref(true),
+      ref(false),
+      ref(new AllNodesOfflineError('btc'))
+    )
+
+    expect(status.value).toBe(TransactionStatus.PENDING)
+  })
+
   it('rejects a pending transaction when the initial lookup exhausts all retries', () => {
     const status = useTransactionStatus(
       ref(false),
@@ -54,6 +70,20 @@ describe('useTransactionStatus', () => {
       undefined,
       undefined,
       ref(true),
+      ref(false)
+    )
+
+    expect(status.value).toBe(TransactionStatus.REJECTED)
+  })
+
+  it('rejects a pending known status on a definitive query error even without loading flags', () => {
+    const status = useTransactionStatus(
+      ref(false),
+      ref('error'),
+      computed(() => TransactionStatus.PENDING),
+      undefined,
+      undefined,
+      ref(false),
       ref(false)
     )
 

--- a/src/components/transactions/hooks/useTransactionStatus.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.ts
@@ -14,6 +14,7 @@ export function useTransactionStatus(
   queryStatus: Ref<QueryStatus>,
   transactionStatus?: Ref<TransactionStatusType | undefined>,
   inconsistentStatus?: Ref<InconsistentStatus>,
+  isInconsistentStatusResolving?: Ref<boolean>,
   additionalStatus?: Ref<TransactionAdditionalStatusType | undefined>,
   isLoadingError?: Ref<boolean | undefined>,
   isRefetchError?: Ref<boolean | undefined>,
@@ -50,6 +51,12 @@ export function useTransactionStatus(
       return resolvedKnownStatus
     }
     if (queryStatus.value === 'success') {
+      if (isInconsistentStatusResolving?.value) {
+        return resolvedKnownStatus === TransactionStatus.CONFIRMED
+          ? TransactionStatus.PENDING
+          : resolvedKnownStatus || TransactionStatus.PENDING
+      }
+
       if (inconsistentStatus?.value) return TransactionStatus.INVALID
 
       return resolvedKnownStatus || TransactionStatus.CONFIRMED

--- a/src/components/transactions/hooks/useTransactionStatus.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.ts
@@ -10,7 +10,9 @@ export function useTransactionStatus(
   inconsistentStatus?: Ref<InconsistentStatus>
 ) {
   return computed(() => {
-    if (queryStatus.value === 'error') return TransactionStatus.REJECTED
+    if (queryStatus.value === 'error') {
+      return transactionStatus?.value || TransactionStatus.REJECTED
+    }
     if (queryStatus.value === 'success') {
       if (inconsistentStatus?.value) return TransactionStatus.INVALID
 

--- a/src/components/transactions/hooks/useTransactionStatus.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.ts
@@ -6,6 +6,7 @@ import {
   TransactionStatus,
   TransactionStatusType
 } from '@/lib/constants'
+import { isTransactionQueryRecoverableError } from '@/hooks/queries/transaction/utils'
 import { InconsistentStatus } from '../utils/getInconsistentStatus'
 
 export function useTransactionStatus(
@@ -15,19 +16,29 @@ export function useTransactionStatus(
   inconsistentStatus?: Ref<InconsistentStatus>,
   additionalStatus?: Ref<TransactionAdditionalStatusType | undefined>,
   isLoadingError?: Ref<boolean | undefined>,
-  isRefetchError?: Ref<boolean | undefined>
+  isRefetchError?: Ref<boolean | undefined>,
+  queryError?: Ref<unknown | null | undefined>
 ) {
   return computed(() => {
     const resolvedKnownStatus =
       additionalStatus?.value === TransactionAdditionalStatus.INSTANT_SEND
         ? TransactionStatus.CONFIRMED
         : transactionStatus?.value
+    const hasRecoverableError = isTransactionQueryRecoverableError(queryError?.value)
+
+    if (hasRecoverableError) {
+      return resolvedKnownStatus || TransactionStatus.PENDING
+    }
 
     if (isRefetchError?.value && resolvedKnownStatus === TransactionStatus.PENDING) {
       return TransactionStatus.REJECTED
     }
 
     if (queryStatus.value === 'error') {
+      if (resolvedKnownStatus === TransactionStatus.PENDING) {
+        return TransactionStatus.REJECTED
+      }
+
       if (isRefetchError?.value && resolvedKnownStatus) {
         return resolvedKnownStatus
       }

--- a/src/components/transactions/hooks/useTransactionStatus.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.ts
@@ -1,22 +1,33 @@
 import type { QueryStatus } from '@tanstack/vue-query'
 import { computed, Ref } from 'vue'
-import { TransactionStatus, TransactionStatusType } from '@/lib/constants'
+import {
+  TransactionAdditionalStatus,
+  TransactionAdditionalStatusType,
+  TransactionStatus,
+  TransactionStatusType
+} from '@/lib/constants'
 import { InconsistentStatus } from '../utils/getInconsistentStatus'
 
 export function useTransactionStatus(
   isFetching: Ref<boolean>,
   queryStatus: Ref<QueryStatus>,
   transactionStatus?: Ref<TransactionStatusType | undefined>,
-  inconsistentStatus?: Ref<InconsistentStatus>
+  inconsistentStatus?: Ref<InconsistentStatus>,
+  additionalStatus?: Ref<TransactionAdditionalStatusType | undefined>
 ) {
   return computed(() => {
+    const resolvedKnownStatus =
+      additionalStatus?.value === TransactionAdditionalStatus.INSTANT_SEND
+        ? TransactionStatus.CONFIRMED
+        : transactionStatus?.value
+
     if (queryStatus.value === 'error') {
-      return transactionStatus?.value || TransactionStatus.REJECTED
+      return resolvedKnownStatus || TransactionStatus.REJECTED
     }
     if (queryStatus.value === 'success') {
       if (inconsistentStatus?.value) return TransactionStatus.INVALID
 
-      return transactionStatus?.value || TransactionStatus.CONFIRMED
+      return resolvedKnownStatus || TransactionStatus.CONFIRMED
     }
     if (isFetching.value) return TransactionStatus.PENDING
 

--- a/src/components/transactions/hooks/useTransactionStatus.ts
+++ b/src/components/transactions/hooks/useTransactionStatus.ts
@@ -13,7 +13,9 @@ export function useTransactionStatus(
   queryStatus: Ref<QueryStatus>,
   transactionStatus?: Ref<TransactionStatusType | undefined>,
   inconsistentStatus?: Ref<InconsistentStatus>,
-  additionalStatus?: Ref<TransactionAdditionalStatusType | undefined>
+  additionalStatus?: Ref<TransactionAdditionalStatusType | undefined>,
+  isLoadingError?: Ref<boolean | undefined>,
+  isRefetchError?: Ref<boolean | undefined>
 ) {
   return computed(() => {
     const resolvedKnownStatus =
@@ -21,8 +23,20 @@ export function useTransactionStatus(
         ? TransactionStatus.CONFIRMED
         : transactionStatus?.value
 
+    if (isRefetchError?.value && resolvedKnownStatus === TransactionStatus.PENDING) {
+      return TransactionStatus.REJECTED
+    }
+
     if (queryStatus.value === 'error') {
-      return resolvedKnownStatus || TransactionStatus.REJECTED
+      if (isRefetchError?.value && resolvedKnownStatus) {
+        return resolvedKnownStatus
+      }
+
+      if (isLoadingError?.value || !resolvedKnownStatus) {
+        return TransactionStatus.REJECTED
+      }
+
+      return resolvedKnownStatus
     }
     if (queryStatus.value === 'success') {
       if (inconsistentStatus?.value) return TransactionStatus.INVALID

--- a/src/components/transactions/utils/getInconsistentStatus.spec.ts
+++ b/src/components/transactions/utils/getInconsistentStatus.spec.ts
@@ -46,6 +46,32 @@ const createAdmTransaction = (
 })
 
 describe('getInconsistentStatus', () => {
+  test('treats native ADM transfers as always consistent', () => {
+    expect(
+      getInconsistentStatus(
+        {
+          id: 'adm-native-1',
+          type: 0,
+          senderId: 'U1111111111111111111',
+          recipientId: 'U2222222222222222222',
+          confirmations: 1,
+          amount: 100000000,
+          fee: 50000000
+        } as any,
+        createAdmTransaction({
+          id: 'adm-native-1',
+          hash: 'adm-native-1',
+          type: 'ADM',
+          amount: 1
+        }),
+        {
+          senderCryptoAddress: SENDER_CRYPTO_ADDRESS,
+          recipientCryptoAddress: RECIPIENT_CRYPTO_ADDRESS
+        }
+      )
+    ).toBe('')
+  })
+
   describe('NO_SENDER_CRYPTO_ADDRESS', () => {
     test('should pass validation when sender crypto address exists', () => {
       const coinTransaction = createCoinTransaction()

--- a/src/components/transactions/utils/getInconsistentStatus.ts
+++ b/src/components/transactions/utils/getInconsistentStatus.ts
@@ -28,7 +28,8 @@ export function getInconsistentStatus(
     recipientCryptoAddress
   }: { senderCryptoAddress?: string; recipientCryptoAddress?: string }
 ): InconsistentStatus {
-  const isAdmTransaction = 'message' in transaction // marker that transaction is and ADM transaction
+  const isAdmTransaction =
+    'message' in transaction || ('type' in transaction && typeof transaction.type === 'number')
   if (isAdmTransaction) {
     return '' // ADM transactions are always consistent
   }

--- a/src/components/transactions/utils/getInconsistentStatus.ts
+++ b/src/components/transactions/utils/getInconsistentStatus.ts
@@ -1,5 +1,5 @@
-import { DecodedChatMessageTransaction } from '@/lib/adamant-api'
-import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
+import type { DecodedChatMessageTransaction } from '@/lib/adamant-api'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 import { CoinTransaction } from '@/lib/nodes/types/transaction'
 import { isStringEqualCI } from '@/lib/textHelpers'
 import { CryptosInfo, CryptoSymbol } from '@/lib/constants'

--- a/src/hooks/queries/transaction/types.ts
+++ b/src/hooks/queries/transaction/types.ts
@@ -1,6 +1,8 @@
 import { MaybeRef } from 'vue'
+import { TransactionStatusType } from '@/lib/constants'
 
 export type UseTransactionQueryParams = {
   refetchOnMount?: boolean
   enabled?: MaybeRef<boolean | undefined>
+  knownStatus?: MaybeRef<TransactionStatusType | undefined>
 }

--- a/src/hooks/queries/transaction/types.ts
+++ b/src/hooks/queries/transaction/types.ts
@@ -1,8 +1,10 @@
 import { MaybeRef } from 'vue'
 import { TransactionStatusType } from '@/lib/constants'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 
 export type UseTransactionQueryParams = {
   refetchOnMount?: boolean
   enabled?: MaybeRef<boolean | undefined>
   knownStatus?: MaybeRef<TransactionStatusType | undefined>
+  knownAdmTransaction?: MaybeRef<NormalizedChatMessageTransaction | undefined>
 }

--- a/src/hooks/queries/transaction/useAdmTransactionQuery.spec.ts
+++ b/src/hooks/queries/transaction/useAdmTransactionQuery.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const useQueryMock = vi.hoisted(() => vi.fn((options) => options))
+const utilsMock = vi.hoisted(() => ({
+  retryFactory: vi.fn(() => 'retry-sentinel'),
+  retryDelayFactory: vi.fn(() => 'retry-delay-sentinel'),
+  refetchIntervalFactory: vi.fn(() => 4321),
+  refetchOnMountFn: vi.fn(() => true)
+}))
+
+vi.mock('@tanstack/vue-query', () => ({
+  useQuery: useQueryMock
+}))
+
+vi.mock('vuex', () => ({
+  useStore: () => ({
+    state: {
+      address: 'U123456789'
+    }
+  })
+}))
+
+vi.mock('./utils', () => utilsMock)
+vi.mock('@/lib/adamant-api', () => ({
+  getTransaction: vi.fn(),
+  decodeTransaction: vi.fn()
+}))
+vi.mock('@/lib/constants', () => ({
+  Cryptos: {
+    ADM: 'ADM'
+  }
+}))
+
+import { useAdmTransactionQuery } from './useAdmTransactionQuery'
+
+describe('useAdmTransactionQuery', () => {
+  it('polls pending ADM transactions and re-fetches them on remount until finalized', () => {
+    useAdmTransactionQuery('adm-tx-id')
+    const query = useQueryMock.mock.calls[0]?.[0]
+
+    expect(useQueryMock).toHaveBeenCalledTimes(1)
+    expect(query.queryKey).toEqual(['transaction', 'ADM', 'adm-tx-id'])
+    expect(query.retry).toBe('retry-sentinel')
+    expect(query.retryDelay).toBe('retry-delay-sentinel')
+    expect(query.refetchOnWindowFocus).toBe(false)
+
+    const refetchInterval = query.refetchInterval({
+      state: {
+        status: 'pending',
+        data: {
+          status: 'PENDING',
+          timestamp: 1_710_000_000
+        }
+      }
+    })
+    expect(refetchInterval).toBe(4321)
+    expect(utilsMock.refetchIntervalFactory).toHaveBeenCalledWith('ADM', 'pending', {
+      status: 'PENDING',
+      timestamp: 1_710_000_000
+    })
+
+    const refetchOnMount = query.refetchOnMount({
+      state: {
+        data: {
+          status: 'REGISTERED'
+        }
+      }
+    })
+    expect(refetchOnMount).toBe(true)
+    expect(utilsMock.refetchOnMountFn).toHaveBeenCalledWith({
+      status: 'REGISTERED'
+    })
+  })
+})

--- a/src/hooks/queries/transaction/useAdmTransactionQuery.spec.ts
+++ b/src/hooks/queries/transaction/useAdmTransactionQuery.spec.ts
@@ -54,10 +54,15 @@ describe('useAdmTransactionQuery', () => {
       }
     })
     expect(refetchInterval).toBe(4321)
-    expect(utilsMock.refetchIntervalFactory).toHaveBeenCalledWith('ADM', 'pending', {
-      status: 'PENDING',
-      timestamp: 1_710_000_000
-    })
+    expect(utilsMock.refetchIntervalFactory).toHaveBeenCalledWith(
+      'ADM',
+      'pending',
+      {
+        status: 'PENDING',
+        timestamp: 1_710_000_000
+      },
+      undefined
+    )
 
     const refetchOnMount = query.refetchOnMount({
       state: {

--- a/src/hooks/queries/transaction/useAdmTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useAdmTransactionQuery.ts
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/vue-query'
 import { MaybeRef, unref } from 'vue'
 import { useStore } from 'vuex'
-import { retryDelayFactory, retryFactory } from './utils'
+import { refetchIntervalFactory, refetchOnMountFn, retryDelayFactory, retryFactory } from './utils'
 
 import { DecodedChatMessageTransaction, decodeTransaction } from '@/lib/adamant-api'
 import * as admApi from '@/lib/adamant-api'
-import { Cryptos } from '@/lib/constants'
+import { Cryptos, TransactionStatusType } from '@/lib/constants'
 import { UseTransactionQueryParams } from './types'
 
 const fetchTransaction = async (transactionId: string, currentUserAdmAddress: string) => {
@@ -26,6 +26,9 @@ export function useAdmTransactionQuery(
   params: UseTransactionQueryParams = {}
 ) {
   const store = useStore()
+  const toTransactionStatusShape = (
+    transaction?: DecodedChatMessageTransaction
+  ): { status?: TransactionStatusType; timestamp?: number } | undefined => transaction
 
   return useQuery({
     queryKey: ['transaction', Cryptos.ADM, transactionId],
@@ -33,9 +36,12 @@ export function useAdmTransactionQuery(
     initialData: {} as DecodedChatMessageTransaction,
     retry: retryFactory(Cryptos.ADM, unref(transactionId)),
     retryDelay: retryDelayFactory(Cryptos.ADM, unref(transactionId)),
-    refetchInterval: false,
+    refetchInterval: ({ state }) =>
+      refetchIntervalFactory(Cryptos.ADM, state.status, toTransactionStatusShape(state.data)),
     refetchOnWindowFocus: false,
-    refetchOnMount: params?.refetchOnMount,
+    refetchOnMount:
+      params?.refetchOnMount ??
+      (({ state }) => refetchOnMountFn(toTransactionStatusShape(state.data))),
     enabled: params.enabled
   })
 }

--- a/src/hooks/queries/transaction/useAdmTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useAdmTransactionQuery.ts
@@ -37,7 +37,12 @@ export function useAdmTransactionQuery(
     retry: retryFactory(Cryptos.ADM, unref(transactionId)),
     retryDelay: retryDelayFactory(Cryptos.ADM, unref(transactionId)),
     refetchInterval: ({ state }) =>
-      refetchIntervalFactory(Cryptos.ADM, state.status, toTransactionStatusShape(state.data)),
+      refetchIntervalFactory(
+        Cryptos.ADM,
+        state.status,
+        toTransactionStatusShape(state.data),
+        state.error
+      ),
     refetchOnWindowFocus: false,
     refetchOnMount:
       params?.refetchOnMount ??

--- a/src/hooks/queries/transaction/useBtcTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useBtcTransactionQuery.ts
@@ -29,7 +29,8 @@ export function useBtcTransactionQuery(
     },
     retry: retryFactory(Cryptos.BTC, unref(transactionId)),
     retryDelay: retryDelayFactory(Cryptos.BTC, unref(transactionId)),
-    refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.BTC, state.status, state.data),
+    refetchInterval: ({ state }) =>
+      refetchIntervalFactory(Cryptos.BTC, state.status, state.data, state.error),
     refetchOnWindowFocus: false,
     refetchOnMount: params?.refetchOnMount ?? (({ state }) => refetchOnMountFn(state.data)),
     enabled: params.enabled

--- a/src/hooks/queries/transaction/useDashTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useDashTransactionQuery.ts
@@ -29,7 +29,8 @@ export function useDashTransactionQuery(
     },
     retry: retryFactory(Cryptos.DASH, unref(transactionId)),
     retryDelay: retryDelayFactory(Cryptos.DASH, unref(transactionId)),
-    refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.DASH, state.status, state.data),
+    refetchInterval: ({ state }) =>
+      refetchIntervalFactory(Cryptos.DASH, state.status, state.data, state.error),
     refetchOnWindowFocus: false,
     refetchOnMount: params?.refetchOnMount ?? (({ state }) => refetchOnMountFn(state.data)),
     enabled: params.enabled

--- a/src/hooks/queries/transaction/useDogeTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useDogeTransactionQuery.ts
@@ -29,7 +29,8 @@ export function useDogeTransactionQuery(
     },
     retry: retryFactory(Cryptos.DOGE, unref(transactionId)),
     retryDelay: retryDelayFactory(Cryptos.DOGE, unref(transactionId)),
-    refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.DOGE, state.status, state.data),
+    refetchInterval: ({ state }) =>
+      refetchIntervalFactory(Cryptos.DOGE, state.status, state.data, state.error),
     refetchOnWindowFocus: false,
     refetchOnMount: params?.refetchOnMount ?? (({ state }) => refetchOnMountFn(state.data)),
     enabled: params.enabled

--- a/src/hooks/queries/transaction/useErc20TransactionQuery.ts
+++ b/src/hooks/queries/transaction/useErc20TransactionQuery.ts
@@ -23,7 +23,8 @@ export function useErc20TransactionQuery(crypto: CryptoSymbol) {
       },
       retry: retryFactory(crypto, unref(transactionId)),
       retryDelay: retryDelayFactory(crypto, unref(transactionId)),
-      refetchInterval: ({ state }) => refetchIntervalFactory(crypto, state.status, state.data),
+      refetchInterval: ({ state }) =>
+        refetchIntervalFactory(crypto, state.status, state.data, state.error),
       refetchOnWindowFocus: false,
       refetchOnMount: params?.refetchOnMount ?? (({ state }) => refetchOnMountFn(state.data)),
       enabled: params.enabled

--- a/src/hooks/queries/transaction/useEthTransactionQuery.ts
+++ b/src/hooks/queries/transaction/useEthTransactionQuery.ts
@@ -25,7 +25,8 @@ export function useEthTransactionQuery(
     },
     retry: retryFactory(Cryptos.ETH, unref(transactionId)),
     retryDelay: retryDelayFactory(Cryptos.ETH, unref(transactionId)),
-    refetchInterval: ({ state }) => refetchIntervalFactory(Cryptos.ETH, state.status, state.data),
+    refetchInterval: ({ state }) =>
+      refetchIntervalFactory(Cryptos.ETH, state.status, state.data, state.error),
     refetchOnWindowFocus: false,
     refetchOnMount: params?.refetchOnMount ?? (({ state }) => refetchOnMountFn(state.data)),
     enabled: params.enabled

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -20,7 +20,11 @@ export function useTransactionStatusQuery(
     data: transaction,
     refetch
   } = useTransactionQuery(transactionId, unref(crypto), params)
-  const inconsistentStatus = useInconsistentStatus(transaction, unref(crypto))
+  const inconsistentStatus = useInconsistentStatus(
+    transaction,
+    unref(crypto),
+    params.knownAdmTransaction
+  )
   const additionalStatus = useTransactionAdditionalStatus(transaction, unref(crypto))
   const transactionStatus = computed(() => {
     if (transaction.value && 'status' in transaction.value) {

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -23,7 +23,8 @@ export function useTransactionStatusQuery(
     if (transaction.value && 'status' in transaction.value) {
       return transaction.value.status
     }
-    return undefined
+
+    return params.knownStatus ? unref(params.knownStatus) : undefined
   })
   const status = useTransactionStatus(
     isFetching,

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -35,6 +35,7 @@ export function useTransactionStatusQuery(
   )
 
   return {
+    transaction,
     queryStatus,
     inconsistentStatus,
     additionalStatus,

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -1,4 +1,5 @@
 import { computed, MaybeRef, unref } from 'vue'
+import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
 import { useInconsistentStatus } from '@/components/transactions/hooks/useInconsistentStatus'
 import { useTransactionStatus } from '@/components/transactions/hooks/useTransactionStatus'
 import { CryptoSymbol } from '@/lib/constants'
@@ -17,6 +18,7 @@ export function useTransactionStatusQuery(
     refetch
   } = useTransactionQuery(transactionId, unref(crypto), params)
   const inconsistentStatus = useInconsistentStatus(transaction, unref(crypto))
+  const additionalStatus = useTransactionAdditionalStatus(transaction, unref(crypto))
   const transactionStatus = computed(() => {
     if (transaction.value && 'status' in transaction.value) {
       return transaction.value.status
@@ -27,12 +29,14 @@ export function useTransactionStatusQuery(
     isFetching,
     queryStatus,
     transactionStatus,
-    inconsistentStatus
+    inconsistentStatus,
+    additionalStatus
   )
 
   return {
     queryStatus,
     inconsistentStatus,
+    additionalStatus,
     status,
     refetch
   }

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -16,6 +16,7 @@ export function useTransactionStatusQuery(
     isFetching,
     isLoadingError,
     isRefetchError,
+    error,
     data: transaction,
     refetch
   } = useTransactionQuery(transactionId, unref(crypto), params)
@@ -35,7 +36,8 @@ export function useTransactionStatusQuery(
     inconsistentStatus,
     additionalStatus,
     isLoadingError,
-    isRefetchError
+    isRefetchError,
+    error
   )
 
   return {
@@ -43,6 +45,7 @@ export function useTransactionStatusQuery(
     queryStatus,
     isLoadingError,
     isRefetchError,
+    error,
     inconsistentStatus,
     additionalStatus,
     status,

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -1,6 +1,6 @@
 import { computed, MaybeRef, unref } from 'vue'
 import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
-import { useInconsistentStatus } from '@/components/transactions/hooks/useInconsistentStatus'
+import { useInconsistentStatusState } from '@/components/transactions/hooks/useInconsistentStatus'
 import { useTransactionStatus } from '@/components/transactions/hooks/useTransactionStatus'
 import { CryptoSymbol } from '@/lib/constants'
 import { useTransactionQuery } from './useTransactionQuery'
@@ -20,11 +20,8 @@ export function useTransactionStatusQuery(
     data: transaction,
     refetch
   } = useTransactionQuery(transactionId, unref(crypto), params)
-  const inconsistentStatus = useInconsistentStatus(
-    transaction,
-    unref(crypto),
-    params.knownAdmTransaction
-  )
+  const { status: inconsistentStatus, isResolving: isInconsistentStatusResolving } =
+    useInconsistentStatusState(transaction, unref(crypto), params.knownAdmTransaction)
   const additionalStatus = useTransactionAdditionalStatus(transaction, unref(crypto))
   const transactionStatus = computed(() => {
     if (transaction.value && 'status' in transaction.value) {
@@ -38,6 +35,7 @@ export function useTransactionStatusQuery(
     queryStatus,
     transactionStatus,
     inconsistentStatus,
+    isInconsistentStatusResolving,
     additionalStatus,
     isLoadingError,
     isRefetchError,
@@ -51,6 +49,7 @@ export function useTransactionStatusQuery(
     isRefetchError,
     error,
     inconsistentStatus,
+    isInconsistentStatusResolving,
     additionalStatus,
     status,
     refetch

--- a/src/hooks/queries/transaction/useTransactionStatusQuery.ts
+++ b/src/hooks/queries/transaction/useTransactionStatusQuery.ts
@@ -14,6 +14,8 @@ export function useTransactionStatusQuery(
   const {
     status: queryStatus,
     isFetching,
+    isLoadingError,
+    isRefetchError,
     data: transaction,
     refetch
   } = useTransactionQuery(transactionId, unref(crypto), params)
@@ -31,12 +33,16 @@ export function useTransactionStatusQuery(
     queryStatus,
     transactionStatus,
     inconsistentStatus,
-    additionalStatus
+    additionalStatus,
+    isLoadingError,
+    isRefetchError
   )
 
   return {
     transaction,
     queryStatus,
+    isLoadingError,
+    isRefetchError,
     inconsistentStatus,
     additionalStatus,
     status,

--- a/src/hooks/queries/transaction/utils.spec.ts
+++ b/src/hooks/queries/transaction/utils.spec.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { Cryptos, CryptosInfo, TransactionStatus } from '@/lib/constants'
+import {
+  getTxFetchInfo,
+  INSTANT_SEND_INTERVAL,
+  INSTANT_SEND_TIME
+} from '@/lib/transactionsFetching'
+import { refetchIntervalFactory, refetchOnMountFn, retryDelayFactory, retryFactory } from './utils'
+
+const pendingGetMock = vi.fn()
+
+vi.mock('@/lib/pending-transactions', () => ({
+  PendingTxStore: {
+    get: (...args: unknown[]) => pendingGetMock(...args)
+  }
+}))
+
+describe('transaction query utils', () => {
+  beforeEach(() => {
+    vi.useRealTimers()
+    pendingGetMock.mockReset()
+  })
+
+  it('uses txFetchInfo from wallet metadata for the supported crypto set', () => {
+    for (const crypto of [
+      Cryptos.ADM,
+      Cryptos.BTC,
+      Cryptos.DASH,
+      Cryptos.DOGE,
+      Cryptos.ETH,
+      Cryptos.USDT
+    ]) {
+      const info = getTxFetchInfo(crypto)
+
+      expect(info.newPendingInterval).toBeGreaterThan(0)
+      expect(info.oldPendingInterval).toBeGreaterThan(0)
+      expect(info.registeredInterval).toBeGreaterThan(0)
+      expect(info.newPendingAttempts).toBeGreaterThan(0)
+      expect(info.oldPendingAttempts).toBeGreaterThan(0)
+    }
+  })
+
+  it('maps ERC-20 txFetchInfo to the ETH chain settings', () => {
+    const ethTxFetchInfo = CryptosInfo[Cryptos.ETH].txFetchInfo!
+
+    expect(getTxFetchInfo(Cryptos.USDT)).toEqual(getTxFetchInfo(Cryptos.ETH))
+    expect(getTxFetchInfo(Cryptos.ETH)).toEqual({
+      newPendingInterval: ethTxFetchInfo.newPendingInterval,
+      oldPendingInterval: ethTxFetchInfo.oldPendingInterval,
+      registeredInterval: ethTxFetchInfo.registeredInterval,
+      newPendingAttempts: ethTxFetchInfo.newPendingAttempts,
+      oldPendingAttempts: ethTxFetchInfo.oldPendingAttempts
+    })
+  })
+
+  it('uses new pending attempts and delays for the locally pending transaction only', () => {
+    pendingGetMock.mockReturnValue({
+      id: 'tx-new'
+    })
+
+    const btcTxFetchInfo = CryptosInfo[Cryptos.BTC].txFetchInfo!
+    const newPendingAttempts = btcTxFetchInfo.newPendingAttempts!
+    const oldPendingAttempts = btcTxFetchInfo.oldPendingAttempts!
+
+    expect(retryFactory(Cryptos.BTC, 'tx-new')(Math.max(newPendingAttempts - 2, 0))).toBe(true)
+    expect(retryFactory(Cryptos.BTC, 'tx-new')(newPendingAttempts - 1)).toBe(false)
+    expect(retryFactory(Cryptos.BTC, 'tx-old')(oldPendingAttempts - 1)).toBe(false)
+
+    expect(retryDelayFactory(Cryptos.BTC, 'tx-new')()).toBe(
+      CryptosInfo[Cryptos.BTC].txFetchInfo!.newPendingInterval
+    )
+    expect(retryDelayFactory(Cryptos.BTC, 'tx-old')()).toBe(
+      CryptosInfo[Cryptos.BTC].txFetchInfo!.oldPendingInterval
+    )
+  })
+
+  it('keeps fast refetching recent Dash registered transactions while InstantSend is still possible', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-22T12:00:00.000Z'))
+
+    expect(
+      refetchIntervalFactory(Cryptos.DASH, 'success', {
+        status: TransactionStatus.REGISTERED,
+        timestamp: Date.now() - 5_000
+      })
+    ).toBe(INSTANT_SEND_INTERVAL)
+
+    expect(
+      refetchIntervalFactory(Cryptos.DASH, 'success', {
+        status: TransactionStatus.REGISTERED,
+        timestamp: Date.now() - INSTANT_SEND_TIME - 1
+      })
+    ).toBe(CryptosInfo[Cryptos.DASH].txFetchInfo!.registeredInterval)
+  })
+
+  it('stops polling only for finalized or failed transactions, not for pending and registered ones', () => {
+    expect(refetchOnMountFn()).toBe(true)
+    expect(refetchOnMountFn({ status: TransactionStatus.PENDING })).toBe(true)
+    expect(refetchOnMountFn({ status: TransactionStatus.REGISTERED })).toBe(true)
+    expect(
+      refetchIntervalFactory(Cryptos.DOGE, 'success', {
+        status: TransactionStatus.REJECTED
+      })
+    ).toBe(false)
+    expect(
+      refetchIntervalFactory(Cryptos.DOGE, 'success', {
+        status: TransactionStatus.CONFIRMED
+      })
+    ).toBe(false)
+  })
+})

--- a/src/hooks/queries/transaction/utils.spec.ts
+++ b/src/hooks/queries/transaction/utils.spec.ts
@@ -1,11 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { Cryptos, CryptosInfo, TransactionStatus } from '@/lib/constants'
+import { AllNodesOfflineError, TransactionNotFound } from '@/lib/nodes/utils/errors'
 import {
   getTxFetchInfo,
   INSTANT_SEND_INTERVAL,
   INSTANT_SEND_TIME
 } from '@/lib/transactionsFetching'
-import { refetchIntervalFactory, refetchOnMountFn, retryDelayFactory, retryFactory } from './utils'
+import {
+  isTransactionQueryRecoverableError,
+  refetchIntervalFactory,
+  refetchOnMountFn,
+  retryDelayFactory,
+  retryFactory
+} from './utils'
 
 const pendingGetMock = vi.fn()
 
@@ -62,9 +69,11 @@ describe('transaction query utils', () => {
     const newPendingAttempts = btcTxFetchInfo.newPendingAttempts!
     const oldPendingAttempts = btcTxFetchInfo.oldPendingAttempts!
 
-    expect(retryFactory(Cryptos.BTC, 'tx-new')(Math.max(newPendingAttempts - 2, 0))).toBe(true)
-    expect(retryFactory(Cryptos.BTC, 'tx-new')(newPendingAttempts - 1)).toBe(false)
-    expect(retryFactory(Cryptos.BTC, 'tx-old')(oldPendingAttempts - 1)).toBe(false)
+    expect(
+      retryFactory(Cryptos.BTC, 'tx-new')(Math.max(newPendingAttempts - 2, 0), undefined)
+    ).toBe(true)
+    expect(retryFactory(Cryptos.BTC, 'tx-new')(newPendingAttempts - 1, undefined)).toBe(false)
+    expect(retryFactory(Cryptos.BTC, 'tx-old')(oldPendingAttempts - 1, undefined)).toBe(false)
 
     expect(retryDelayFactory(Cryptos.BTC, 'tx-new')()).toBe(
       CryptosInfo[Cryptos.BTC].txFetchInfo!.newPendingInterval
@@ -72,6 +81,13 @@ describe('transaction query utils', () => {
     expect(retryDelayFactory(Cryptos.BTC, 'tx-old')()).toBe(
       CryptosInfo[Cryptos.BTC].txFetchInfo!.oldPendingInterval
     )
+  })
+
+  it('does not spend txFetchInfo retry budget on recoverable connectivity errors', () => {
+    const recoverableError = new AllNodesOfflineError('btc')
+
+    expect(retryFactory(Cryptos.BTC, 'tx-any')(10_000, recoverableError)).toBe(true)
+    expect(isTransactionQueryRecoverableError(recoverableError)).toBe(true)
   })
 
   it('keeps fast refetching recent Dash registered transactions while InstantSend is still possible', () => {
@@ -106,6 +122,32 @@ describe('transaction query utils', () => {
       refetchIntervalFactory(Cryptos.DOGE, 'success', {
         status: TransactionStatus.CONFIRMED
       })
+    ).toBe(false)
+  })
+
+  it('keeps polling registered transactions after recoverable lookup errors', () => {
+    expect(
+      refetchIntervalFactory(
+        Cryptos.BTC,
+        'error',
+        {
+          status: TransactionStatus.REGISTERED
+        },
+        new AllNodesOfflineError('btc')
+      )
+    ).toBe(CryptosInfo[Cryptos.BTC].txFetchInfo!.registeredInterval)
+  })
+
+  it('stops polling when the lookup error definitively says the transaction does not exist', () => {
+    expect(
+      refetchIntervalFactory(
+        Cryptos.BTC,
+        'error',
+        {
+          status: TransactionStatus.PENDING
+        },
+        new TransactionNotFound('tx-id', Cryptos.BTC)
+      )
     ).toBe(false)
   })
 })

--- a/src/hooks/queries/transaction/utils.ts
+++ b/src/hooks/queries/transaction/utils.ts
@@ -45,7 +45,7 @@ export function retryDelayFactory(crypto: CryptoSymbol, transactionId: string) {
 export function refetchIntervalFactory(
   crypto: CryptoSymbol,
   queryStatus: QueryStatus,
-  transaction?: { status: TransactionStatusType; timestamp?: number }
+  transaction?: { status?: TransactionStatusType; timestamp?: number }
 ) {
   const txFetchInfo = getTxFetchInfo(crypto)
 
@@ -67,9 +67,10 @@ export function refetchIntervalFactory(
   return txFetchInfo.registeredInterval
 }
 
-export function refetchOnMountFn(transaction?: { status: TransactionStatusType }) {
+export function refetchOnMountFn(transaction?: { status?: TransactionStatusType }) {
   return (
     !transaction ||
+    !transaction?.status ||
     transaction?.status === TransactionStatus.PENDING ||
     transaction?.status === TransactionStatus.REGISTERED
   )

--- a/src/hooks/queries/transaction/utils.ts
+++ b/src/hooks/queries/transaction/utils.ts
@@ -7,15 +7,116 @@ import {
 } from '@/lib/constants'
 import { PendingTxStore } from '@/lib/pending-transactions'
 import {
+  AllNodesDisabledError,
+  AllNodesOfflineError,
+  isAllNodesDisabledError,
+  isAllNodesOfflineError,
+  isNodeOfflineError,
+  NodeOfflineError,
+  TransactionNotFound
+} from '@/lib/nodes/utils/errors'
+import {
   getTxFetchInfo,
   INSTANT_SEND_INTERVAL,
   INSTANT_SEND_TIME
 } from '@/lib/transactionsFetching'
 
+export function isTransactionQueryRecoverableError(error: unknown) {
+  if (!error || typeof error !== 'object') {
+    return typeof navigator !== 'undefined' && navigator.onLine === false
+  }
+
+  if (
+    error instanceof NodeOfflineError ||
+    error instanceof AllNodesOfflineError ||
+    error instanceof AllNodesDisabledError ||
+    isNodeOfflineError(error as Error) ||
+    isAllNodesOfflineError(error as Error) ||
+    isAllNodesDisabledError(error as Error)
+  ) {
+    return true
+  }
+
+  const networkError = error as {
+    response?: { status?: number }
+    request?: unknown
+    code?: string
+    name?: string
+    message?: string
+  }
+
+  if (typeof navigator !== 'undefined' && navigator.onLine === false) {
+    return true
+  }
+
+  if (networkError.code === 'ERR_CANCELED' || networkError.name === 'CanceledError') {
+    return true
+  }
+
+  if (!networkError.response && networkError.request) {
+    return true
+  }
+
+  const recoverableCodes = new Set([
+    'ECONNABORTED',
+    'ECONNREFUSED',
+    'EHOSTUNREACH',
+    'ENETUNREACH',
+    'ENOTFOUND',
+    'ERR_NETWORK',
+    'ETIMEDOUT'
+  ])
+
+  if (networkError.code && recoverableCodes.has(networkError.code)) {
+    return true
+  }
+
+  const statusCode = networkError.response?.status
+  if (typeof statusCode === 'number' && statusCode >= 500) {
+    return true
+  }
+
+  const message = (networkError.message || '').toLowerCase()
+
+  return (
+    message.includes('failed to fetch') ||
+    message.includes('network error') ||
+    message.includes('timeout') ||
+    message.includes('offline')
+  )
+}
+
+export function isTransactionQueryNotFoundError(error: unknown) {
+  if (error instanceof TransactionNotFound) {
+    return true
+  }
+
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const networkError = error as {
+    response?: { status?: number }
+    message?: string
+  }
+
+  if (networkError.response?.status === 404) {
+    return true
+  }
+
+  const message = (networkError.message || '').toLowerCase()
+
+  return message.includes('transaction not found')
+}
+
 export function retryFactory(crypto: CryptoSymbol, transactionId: string) {
   const txFetchInfo = getTxFetchInfo(crypto)
 
-  return (failureCount: number): boolean => {
+  return (failureCount: number, error: unknown): boolean => {
+    if (isTransactionQueryRecoverableError(error)) {
+      return true
+    }
+
     const pendingTransaction = PendingTxStore.get(crypto)
     const isPendingTransaction = pendingTransaction?.id === transactionId
 
@@ -45,16 +146,20 @@ export function retryDelayFactory(crypto: CryptoSymbol, transactionId: string) {
 export function refetchIntervalFactory(
   crypto: CryptoSymbol,
   queryStatus: QueryStatus,
-  transaction?: { status?: TransactionStatusType; timestamp?: number }
+  transaction?: { status?: TransactionStatusType; timestamp?: number },
+  error?: unknown
 ) {
   const txFetchInfo = getTxFetchInfo(crypto)
 
   if (
-    queryStatus === 'error' ||
     transaction?.status === TransactionStatus.CONFIRMED ||
     transaction?.status === TransactionStatus.REJECTED
   ) {
     // Do not refetch if transaction status is considered finalized
+    return false
+  }
+
+  if (queryStatus === 'error' && !isTransactionQueryRecoverableError(error)) {
     return false
   }
 

--- a/src/hooks/queries/useKVSCryptoAddress.ts
+++ b/src/hooks/queries/useKVSCryptoAddress.ts
@@ -17,11 +17,11 @@ export function useKVSCryptoAddress(
 
   const isEnabled = computed(() => !!admAddress.value)
 
-  const { data } = useQuery({
+  const query = useQuery({
     queryKey: ['KVS', crypto, admAddress],
     queryFn: fetchCryptoAddress,
     enabled: isEnabled
   })
 
-  return data
+  return query
 }

--- a/src/lib/adamant-api/send-tokens.offline.spec.js
+++ b/src/lib/adamant-api/send-tokens.offline.spec.js
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { admClientMock, storeMock } = vi.hoisted(() => ({
+  admClientMock: {
+    post: vi.fn()
+  },
+  storeMock: {
+    state: {
+      address: ''
+    },
+    getters: {
+      publicKey: () => undefined
+    },
+    commit: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/nodes/adm', () => ({
+  default: admClientMock
+}))
+
+vi.mock('@/lib/idb/crypto', () => ({
+  encryptPassword: vi.fn()
+}))
+
+vi.mock('@/lib/idb/state', () => ({
+  restoreState: vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  i18n: {
+    global: {
+      t: (key) => key
+    }
+  }
+}))
+
+vi.mock('@/store', () => ({
+  default: storeMock
+}))
+
+vi.mock('@/utils/devTools/logger', () => ({
+  logger: {
+    log: vi.fn()
+  }
+}))
+
+vi.mock('sodium-browserify-tweetnacl', async () => {
+  const nacl = await import('tweetnacl/nacl-fast')
+
+  return {
+    default: {
+      crypto_sign_seed_keypair(seed) {
+        const keyPair = nacl.sign.keyPair.fromSeed(
+          seed instanceof Uint8Array ? seed : new Uint8Array(seed)
+        )
+
+        return {
+          publicKey: Buffer.from(keyPair.publicKey),
+          secretKey: Buffer.from(keyPair.secretKey)
+        }
+      },
+      crypto_sign_detached(message, secretKey) {
+        return Buffer.from(
+          nacl.sign.detached(
+            message instanceof Uint8Array ? message : new Uint8Array(message),
+            secretKey instanceof Uint8Array ? secretKey : new Uint8Array(secretKey)
+          )
+        )
+      }
+    }
+  }
+})
+
+import { unlock, sendTokens } from './index'
+import { Transactions } from '@/lib/constants'
+
+const TEST_ACCOUNT_PASSPHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const ADM_RECIPIENT = 'U12345678901234567890'
+
+describe('offline ADM send builder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('builds and signs an ADM send transaction with the test account before submission', async () => {
+    let capturedTransaction
+
+    admClientMock.post.mockImplementation(async (_url, payloadFactory) => {
+      const payload = payloadFactory({ timeDelta: 0 })
+      capturedTransaction = payload.transaction
+
+      return {
+        success: true,
+        transactionId: 'adm-test-transaction-id'
+      }
+    })
+
+    const senderAddress = unlock(TEST_ACCOUNT_PASSPHRASE)
+    const result = await sendTokens(ADM_RECIPIENT, 1.25)
+
+    expect(result).toEqual({
+      success: true,
+      transactionId: 'adm-test-transaction-id'
+    })
+    expect(capturedTransaction).toMatchObject({
+      type: Transactions.SEND,
+      senderId: senderAddress,
+      recipientId: ADM_RECIPIENT,
+      amount: 125000000
+    })
+    expect(capturedTransaction.senderPublicKey).toMatch(/^[0-9a-f]+$/)
+    expect(capturedTransaction.signature).toMatch(/^[0-9a-f]+$/)
+    expect(capturedTransaction.timestamp).toBeTypeOf('number')
+  })
+})

--- a/src/lib/bitcoin/bitcoin-utils.js
+++ b/src/lib/bitcoin/bitcoin-utils.js
@@ -1,6 +1,10 @@
 import * as bitcoin from 'bitcoinjs-lib'
 import { BigNumber } from '@/lib/bignumber'
 
+const toRoundedDownIntegerString = (amount, multiplier) => {
+  return new BigNumber(amount).times(multiplier).decimalPlaces(0, BigNumber.ROUND_DOWN).toFixed(0)
+}
+
 /**
  * Checks if the supplied string is a valid BTC address
  * @param {string} address address to check
@@ -17,9 +21,9 @@ export function isValidAddress(address) {
 }
 
 export function convertToSmallestUnit(amount, multiplier) {
-  return Math.floor(new BigNumber(amount).times(multiplier).toNumber())
+  return Number(toRoundedDownIntegerString(amount, multiplier))
 }
 
 export function convertToBigIntSmallestUnit(amount, multiplier) {
-  return BigInt(convertToSmallestUnit(amount, multiplier))
+  return BigInt(toRoundedDownIntegerString(amount, multiplier))
 }

--- a/src/lib/bitcoin/bitcoin-utils.js
+++ b/src/lib/bitcoin/bitcoin-utils.js
@@ -19,3 +19,7 @@ export function isValidAddress(address) {
 export function convertToSmallestUnit(amount, multiplier) {
   return Math.floor(new BigNumber(amount).times(multiplier).toNumber())
 }
+
+export function convertToBigIntSmallestUnit(amount, multiplier) {
+  return BigInt(convertToSmallestUnit(amount, multiplier))
+}

--- a/src/lib/bitcoin/bitcoin-utils.spec.js
+++ b/src/lib/bitcoin/bitcoin-utils.spec.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { convertToBigIntSmallestUnit, convertToSmallestUnit } from './bitcoin-utils'
+
+describe('bitcoin-utils', () => {
+  it('converts to bigint smallest units without losing precision for large values', () => {
+    const amount = '123456789.98765432'
+    const multiplier = 100000000
+
+    expect(convertToBigIntSmallestUnit(amount, multiplier)).toBe(12345678998765432n)
+  })
+
+  it('keeps number conversion behavior for safe integer-sized values', () => {
+    expect(convertToSmallestUnit('0.00002610', 100000000)).toBe(2610)
+  })
+})

--- a/src/lib/bitcoin/btc-base-api.js
+++ b/src/lib/bitcoin/btc-base-api.js
@@ -1,9 +1,8 @@
 import * as bitcoin from 'bitcoinjs-lib'
 
 import networks from './networks'
-import { BigNumber } from '../bignumber'
-import { isPositiveNumber } from '@/lib/numericHelpers'
 import { CryptosInfo } from '../constants'
+import { convertToBigIntSmallestUnit } from './bitcoin-utils'
 
 import { ECPairFactory } from 'ecpair'
 import * as tinysecp from 'tiny-secp256k1'
@@ -137,20 +136,20 @@ export default class BtcBaseApi {
    * @returns {string}
    */
   buildTransaction(address, amount, unspents, fee) {
-    amount = new BigNumber(amount).times(this.multiplier).toNumber()
-    amount = Math.floor(amount)
+    const localAmount = convertToBigIntSmallestUnit(amount, this.multiplier)
+    const heldFee = convertToBigIntSmallestUnit(fee, this.multiplier)
 
     const txb = new bitcoin.Psbt({
       network: this._network
     })
     txb.setVersion(1)
 
-    const target = amount + new BigNumber(fee).times(this.multiplier).toNumber()
-    let transferAmount = 0
+    const target = localAmount + heldFee
+    let transferAmount = 0n
     let inputs = 0
 
     unspents.forEach((tx) => {
-      const amt = Math.floor(tx.amount)
+      const amt = BigInt(Math.floor(tx.amount))
       if (transferAmount < target) {
         txb.addInput({
           hash: tx.txid,
@@ -164,12 +163,12 @@ export default class BtcBaseApi {
 
     txb.addOutput({
       address,
-      value: amount
+      value: localAmount
     })
     // This is a necessary step
     // If we'll not add a change to output, it will burn in hell
     const change = transferAmount - target
-    if (isPositiveNumber(change)) {
+    if (change > 0n) {
       txb.addOutput({
         address: this._address,
         value: change

--- a/src/lib/bitcoin/btc-base-api.js
+++ b/src/lib/bitcoin/btc-base-api.js
@@ -78,8 +78,8 @@ export default class BtcBaseApi {
 
     const hex = await this.buildTransaction(address, amount, unspents, fee)
 
-    let txid = bitcoin.crypto.sha256(Buffer.from(hex, 'hex'))
-    txid = bitcoin.crypto.sha256(Buffer.from(txid))
+    let txid = Buffer.from(bitcoin.crypto.sha256(Buffer.from(hex, 'hex')))
+    txid = Buffer.from(bitcoin.crypto.sha256(txid))
     txid = txid.toString('hex').match(/.{2}/g).reverse().join('')
 
     return { hex, txid }

--- a/src/lib/bitcoin/btc-base-api.js
+++ b/src/lib/bitcoin/btc-base-api.js
@@ -1,4 +1,5 @@
 import * as bitcoin from 'bitcoinjs-lib'
+import BigNumber from 'bignumber.js'
 
 import networks from './networks'
 import { CryptosInfo } from '../constants'
@@ -240,9 +241,9 @@ export default class BtcBaseApi {
 
     let fee = tx.fees
     if (!fee) {
-      const totalIn = tx.vin.reduce((sum, x) => sum + (x.value ? +x.value : 0), 0)
-      const totalOut = tx.vout.reduce((sum, x) => sum + (x.value ? +x.value : 0), 0)
-      fee = totalIn - totalOut
+      const totalIn = tx.vin.reduce((sum, x) => sum.plus(x.value ? x.value : 0), new BigNumber(0))
+      const totalOut = tx.vout.reduce((sum, x) => sum.plus(x.value ? x.value : 0), new BigNumber(0))
+      fee = totalIn.minus(totalOut).toNumber()
     }
 
     const height = tx.height

--- a/src/lib/bitcoin/btc-base-api.spec.js
+++ b/src/lib/bitcoin/btc-base-api.spec.js
@@ -73,4 +73,32 @@ describe('BtcBaseApi.buildTransaction', () => {
       })
     )
   })
+
+  it('calculates normalized BTC-like fees without floating-point drift', () => {
+    const api = Object.create(BtcBaseApi.prototype)
+    api._address = 'Xowner'
+
+    const normalized = api._mapTransaction({
+      txid: 'b'.repeat(64),
+      vin: [
+        {
+          address: 'Xowner',
+          value: 0.0014
+        }
+      ],
+      vout: [
+        {
+          value: 0.0013,
+          scriptPubKey: {
+            addresses: ['Xrecipient']
+          }
+        }
+      ],
+      confirmations: 0,
+      time: 1,
+      height: 1
+    })
+
+    expect(normalized.fee).toBe(0.0001)
+  })
 })

--- a/src/lib/bitcoin/btc-base-api.spec.js
+++ b/src/lib/bitcoin/btc-base-api.spec.js
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const addOutputMock = vi.fn()
+
+vi.mock('bitcoinjs-lib', () => ({
+  Psbt: class {
+    setVersion() {}
+
+    addInput() {}
+
+    addOutput(output) {
+      addOutputMock(output)
+    }
+
+    signInput() {}
+
+    finalizeAllInputs() {}
+
+    extractTransaction() {
+      return {
+        toHex: () => 'deadbeef'
+      }
+    }
+  }
+}))
+
+vi.mock('ecpair', () => ({
+  ECPairFactory: () => ({})
+}))
+
+vi.mock('tiny-secp256k1', () => ({}))
+
+import BtcBaseApi from './btc-base-api'
+
+describe('BtcBaseApi.buildTransaction', () => {
+  beforeEach(() => {
+    addOutputMock.mockClear()
+  })
+
+  it('uses bigint outputs for bitcoinjs-lib v7 compatible BTC transactions', () => {
+    const api = Object.create(BtcBaseApi.prototype)
+    api._network = {}
+    api._keyPair = {}
+    api._address = '1BoatSLRHtKNngkdXEeobR76b53LETtpyT'
+
+    api.buildTransaction(
+      'bc1q35029naja6jpazkefs328varxvr0kjm69r9wcv',
+      0.0000261,
+      [
+        {
+          txid: 'a'.repeat(64),
+          amount: 6000,
+          vout: 0,
+          txHex: '00'
+        }
+      ],
+      0.00002525
+    )
+
+    expect(addOutputMock).toHaveBeenCalledTimes(2)
+    expect(addOutputMock).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        address: 'bc1q35029naja6jpazkefs328varxvr0kjm69r9wcv',
+        value: 2610n
+      })
+    )
+    expect(addOutputMock).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        address: '1BoatSLRHtKNngkdXEeobR76b53LETtpyT',
+        value: 865n
+      })
+    )
+  })
+})

--- a/src/lib/bitcoin/doge-api.js
+++ b/src/lib/bitcoin/doge-api.js
@@ -16,8 +16,6 @@ const POST_CONFIG = {
 }
 
 export const CHUNK_SIZE = 20
-// P2PKH output size (https://gist.github.com/junderw/b43af3253ea5865ed52cb51c200ac19c)
-export const OUTPUTS_COMPENSATION = 34 * 4
 export const NB_BLOCKS = 5 // Number of last blocks
 
 export default class DogeApi extends BtcBaseApi {
@@ -53,7 +51,6 @@ export default class DogeApi extends BtcBaseApi {
     const target = localAmount + BigInt(heldFee)
     let transferAmount = 0n
     let inputsCount = 0
-    let estimatedTxBytes = 0
 
     for (const tx of unspents) {
       if (transferAmount >= target) {
@@ -66,7 +63,6 @@ export default class DogeApi extends BtcBaseApi {
         nonWitnessUtxo: buffer
       })
       transferAmount += BigInt(tx.amount)
-      estimatedTxBytes += buffer.length
       inputsCount++
     }
 
@@ -75,20 +71,9 @@ export default class DogeApi extends BtcBaseApi {
       value: localAmount
     })
 
-    // Estimated fee based on https://github.com/dogecoin/dogecoin/blob/master/doc/fee-recommendation.md
-    const currentFeeRate = await this.getFeePerByte()
-    let estimatedFee = Math.floor(
-      new BigNumber(currentFeeRate)
-        .times(estimatedTxBytes + OUTPUTS_COMPENSATION)
-        .times(this.multiplier)
-        .toNumber()
-    )
-
-    estimatedFee = Math.min(estimatedFee, heldFee)
-
     // This is a necessary step
     // If we'll not add a difference to output, it will burn in hell
-    const difference = transferAmount - localAmount - BigInt(estimatedFee)
+    const difference = transferAmount - localAmount - BigInt(heldFee)
     if (difference > 0n) {
       psbt.addOutput({
         address: this._address,

--- a/src/lib/bitcoin/doge-api.js
+++ b/src/lib/bitcoin/doge-api.js
@@ -2,10 +2,9 @@ import BtcBaseApi from './btc-base-api'
 import { Cryptos } from '../constants'
 import { BigNumber } from '../bignumber'
 import * as bitcoin from 'bitcoinjs-lib'
-import { isPositiveNumber } from '../numericHelpers'
 import { ECPairFactory } from 'ecpair'
 import * as tinysecp from 'tiny-secp256k1'
-import { convertToSmallestUnit } from './bitcoin-utils'
+import { convertToBigIntSmallestUnit, convertToSmallestUnit } from './bitcoin-utils'
 import { dogeIndexer } from '../../lib/nodes'
 
 const ECPairAPI = ECPairFactory(tinysecp)
@@ -42,7 +41,7 @@ export default class DogeApi extends BtcBaseApi {
 
   /** @override */
   async buildTransaction(address, amount, unspents, fee) {
-    const localAmount = convertToSmallestUnit(amount, this.multiplier)
+    const localAmount = convertToBigIntSmallestUnit(amount, this.multiplier)
     const heldFee = convertToSmallestUnit(fee, this.multiplier)
 
     const psbt = new bitcoin.Psbt({
@@ -51,8 +50,8 @@ export default class DogeApi extends BtcBaseApi {
     psbt.setVersion(1)
     psbt.setMaximumFeeRate(heldFee)
 
-    const target = localAmount + heldFee
-    let transferAmount = 0
+    const target = localAmount + BigInt(heldFee)
+    let transferAmount = 0n
     let inputsCount = 0
     let estimatedTxBytes = 0
 
@@ -66,12 +65,10 @@ export default class DogeApi extends BtcBaseApi {
         index: tx.vout,
         nonWitnessUtxo: buffer
       })
-      transferAmount += tx.amount
+      transferAmount += BigInt(tx.amount)
       estimatedTxBytes += buffer.length
       inputsCount++
     }
-
-    transferAmount = Math.floor(transferAmount)
 
     psbt.addOutput({
       address,
@@ -91,8 +88,8 @@ export default class DogeApi extends BtcBaseApi {
 
     // This is a necessary step
     // If we'll not add a difference to output, it will burn in hell
-    const difference = transferAmount - localAmount - estimatedFee
-    if (isPositiveNumber(difference)) {
+    const difference = transferAmount - localAmount - BigInt(estimatedFee)
+    if (difference > 0n) {
       psbt.addOutput({
         address: this._address,
         value: difference

--- a/src/lib/bitcoin/offline-send-builders.spec.js
+++ b/src/lib/bitcoin/offline-send-builders.spec.js
@@ -1,0 +1,219 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as bitcoin from 'bitcoinjs-lib'
+import { Buffer } from 'buffer'
+
+const TEST_PUBLIC_KEY = Buffer.from(
+  '034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa',
+  'hex'
+)
+
+vi.mock('ecpair', () => ({
+  ECPairFactory: () => ({
+    fromPrivateKey: () => ({
+      publicKey: TEST_PUBLIC_KEY
+    }),
+    fromPublicKey: () => ({
+      verify: () => true
+    })
+  })
+}))
+
+vi.mock('tiny-secp256k1', () => ({}))
+
+vi.mock('bitcoinjs-lib', async () => {
+  const actual = await vi.importActual('bitcoinjs-lib')
+
+  class FakePsbt {
+    constructor({ network }) {
+      this.network = network
+      this.inputs = []
+      this.outputs = []
+    }
+
+    setVersion() {}
+
+    setMaximumFeeRate() {}
+
+    addInput(input) {
+      this.inputs.push(input)
+    }
+
+    addOutput(output) {
+      this.outputs.push(output)
+    }
+
+    signInput() {}
+
+    validateSignaturesOfInput() {
+      return true
+    }
+
+    finalizeAllInputs() {}
+
+    extractTransaction() {
+      const tx = new actual.Transaction()
+
+      tx.version = 1
+      this.inputs.forEach(() => tx.addInput(Buffer.alloc(32, 1), 0))
+      this.outputs.forEach(({ address, value }) => {
+        tx.addOutput(
+          actual.address.toOutputScript(address, this.network),
+          typeof value === 'bigint' ? value : BigInt(value)
+        )
+      })
+
+      return tx
+    }
+  }
+
+  return {
+    ...actual,
+    crypto: {
+      ...actual.crypto,
+      sha256(value) {
+        return Buffer.from(actual.crypto.sha256(value))
+      }
+    },
+    Psbt: FakePsbt
+  }
+})
+
+import BitcoinApi from './bitcoin-api'
+import DogeApi from './doge-api'
+import DashApi from './dash-api'
+import networks from './networks'
+import validateAddress from '@/lib/validateAddress'
+import { Cryptos } from '@/lib/constants'
+
+const TEST_ACCOUNT_PASSPHRASE =
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+
+function createRecipientAddresses(crypto) {
+  if (crypto === Cryptos.BTC) {
+    return [
+      ['p2pkh', '1Q1pE5vPGEEMqRcVRMbtBK842Y6Pzo6nK9'],
+      ['p2sh', '3PFpzMLrKWsphFtc8BesF3MGPnimKMuF4x'],
+      ['p2wpkh', 'bc1ql3e9pgs3mmwuwrh95fecme0s0qtn2880lsvsd5']
+    ]
+  }
+
+  return [
+    crypto === Cryptos.DOGE
+      ? ['p2pkh', 'DU9umLs2Ze8eNRo69wbSj5HeufphJawFPh']
+      : ['p2pkh', 'Xyhf4LaHDwSwzND5HEv72qoqrsg625rCMt'],
+    crypto === Cryptos.DOGE
+      ? ['p2sh', 'ABhQshCgMtU4f7g6Uqr51Tjv96HMQKRDFq']
+      : ['p2sh', '7mfny3Qx6ogokWqaLKrA6i7CN4jh9dsPqy']
+  ]
+}
+
+function createFundingUtxo(address, network, amount) {
+  const tx = new bitcoin.Transaction()
+
+  tx.version = 1
+  tx.addInput(Buffer.alloc(32, 1), 0)
+  tx.addOutput(bitcoin.address.toOutputScript(address, network), BigInt(amount))
+
+  return {
+    txHex: tx.toHex(),
+    txid: tx.getId(),
+    amount,
+    vout: 0
+  }
+}
+
+function decodeOutputs(hex, network) {
+  const transaction = bitcoin.Transaction.fromHex(hex)
+
+  return transaction.outs.map((output) => ({
+    address: bitcoin.address.fromOutputScript(output.script, network),
+    value: output.value
+  }))
+}
+
+async function expectOfflineTransfer({
+  api,
+  crypto,
+  recipientAddress,
+  amount,
+  fee,
+  fundingAmount,
+  extraMocks = () => {}
+}) {
+  const fundingUtxo = createFundingUtxo(api.address, networks[crypto], fundingAmount)
+
+  vi.spyOn(api, 'getUnspents').mockResolvedValue([fundingUtxo])
+  vi.spyOn(api, 'getTransactionHex').mockResolvedValue(fundingUtxo.txHex)
+  extraMocks(api)
+
+  const transaction = await api.createTransaction(recipientAddress, amount, fee)
+  const outputs = decodeOutputs(transaction.hex, networks[crypto])
+
+  expect(validateAddress(crypto, recipientAddress)).toBe(true)
+  expect(transaction.txid).toMatch(/^[0-9a-f]{64}$/)
+  expect(outputs[0]).toEqual({
+    address: recipientAddress,
+    value: BigInt(Math.floor(amount * 1e8))
+  })
+  expect(outputs[1]).toEqual({
+    address: api.address,
+    value: BigInt(fundingAmount - Math.floor((amount + fee) * 1e8))
+  })
+}
+
+describe('offline bitcoin-like send builders', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it.each(createRecipientAddresses(Cryptos.BTC))(
+    'builds a signed BTC transaction for %s recipients',
+    async (_type, recipientAddress) => {
+      const api = new BitcoinApi(TEST_ACCOUNT_PASSPHRASE)
+
+      await expectOfflineTransfer({
+        api,
+        crypto: Cryptos.BTC,
+        recipientAddress,
+        amount: 0.0001,
+        fee: 0.00001,
+        fundingAmount: 50_000
+      })
+    }
+  )
+
+  it.each(createRecipientAddresses(Cryptos.DOGE))(
+    'builds a signed DOGE transaction for %s recipients',
+    async (_type, recipientAddress) => {
+      const api = new DogeApi(TEST_ACCOUNT_PASSPHRASE)
+
+      await expectOfflineTransfer({
+        api,
+        crypto: Cryptos.DOGE,
+        recipientAddress,
+        amount: 1.5,
+        fee: 1,
+        fundingAmount: 500_000_000,
+        extraMocks: () => {
+          vi.spyOn(api, 'getFeePerByte').mockResolvedValue(1)
+        }
+      })
+    }
+  )
+
+  it.each(createRecipientAddresses(Cryptos.DASH))(
+    'builds a signed DASH transaction for %s recipients',
+    async (_type, recipientAddress) => {
+      const api = new DashApi(TEST_ACCOUNT_PASSPHRASE)
+
+      await expectOfflineTransfer({
+        api,
+        crypto: Cryptos.DASH,
+        recipientAddress,
+        amount: 0.01,
+        fee: 0.0001,
+        fundingAmount: 5_000_000
+      })
+    }
+  )
+})

--- a/src/lib/bitcoin/offline-send-builders.spec.js
+++ b/src/lib/bitcoin/offline-send-builders.spec.js
@@ -131,6 +131,13 @@ function decodeOutputs(hex, network) {
   }))
 }
 
+function calculateUtxoFee(hex, totalInputAmount) {
+  const transaction = bitcoin.Transaction.fromHex(hex)
+  const totalOut = transaction.outs.reduce((sum, output) => sum + output.value, 0n)
+
+  return BigInt(totalInputAmount) - totalOut
+}
+
 async function expectOfflineTransfer({
   api,
   crypto,
@@ -151,6 +158,7 @@ async function expectOfflineTransfer({
 
   expect(validateAddress(crypto, recipientAddress)).toBe(true)
   expect(transaction.txid).toMatch(/^[0-9a-f]{64}$/)
+  expect(calculateUtxoFee(transaction.hex, fundingAmount)).toBe(BigInt(Math.floor(fee * 1e8)))
   expect(outputs[0]).toEqual({
     address: recipientAddress,
     value: BigInt(Math.floor(amount * 1e8))
@@ -193,10 +201,7 @@ describe('offline bitcoin-like send builders', () => {
         recipientAddress,
         amount: 1.5,
         fee: 1,
-        fundingAmount: 500_000_000,
-        extraMocks: () => {
-          vi.spyOn(api, 'getFeePerByte').mockResolvedValue(1)
-        }
+        fundingAmount: 500_000_000
       })
     }
   )

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -181,10 +181,14 @@ export const tsIcon = function (status: TransactionStatusType) {
 }
 
 export const tsColor = function (status: TransactionStatusType) {
+  if (status === TransactionStatus.CONFIRMED) {
+    return 'var(--a-color-status-success)'
+  }
+
   if (status === TransactionStatus.REJECTED) {
-    return 'red'
+    return 'var(--a-color-status-danger)'
   } else if (status === TransactionStatus.INVALID || status === TransactionStatus.UNKNOWN) {
-    return 'yellow'
+    return 'var(--a-color-status-attention)'
   }
   return ''
 }

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   mdiCheck,
+  mdiClockCheckOutline,
   mdiClockOutline,
   mdiCloseCircleOutline,
   mdiAlertOutline,
@@ -152,8 +153,12 @@ export const TransactionAdditionalStatus = {
 }
 
 export const tsIcon = function (status: TransactionStatusType) {
-  if (status === TransactionStatus.CONFIRMED || status === TransactionStatus.REGISTERED) {
+  if (status === TransactionStatus.CONFIRMED) {
     return mdiCheck
+  }
+
+  if (status === TransactionStatus.REGISTERED) {
+    return mdiClockCheckOutline
   }
 
   if (status === TransactionStatus.PENDING) {

--- a/src/lib/constants/index.ts
+++ b/src/lib/constants/index.ts
@@ -135,6 +135,8 @@ export type TransactionStatusType =
   | 'INVALID'
   | 'UNKNOWN'
 
+export type TransactionAdditionalStatusType = false | 'instant_send' | 'adm_registered'
+
 /** Status of ADM or coin transaction */
 export const TransactionStatus: Record<TransactionStatusType, TransactionStatusType> = {
   CONFIRMED: 'CONFIRMED', // Tx has at least 1 network confirmation
@@ -150,7 +152,7 @@ export const TransactionAdditionalStatus = {
   NONE: false,
   INSTANT_SEND: 'instant_send', // Dash InstantSend enabled transaction
   ADM_REGISTERED: 'adm_registered' // ADM tx, registered in a blockchain, but has 0 confirmations yet
-}
+} as const satisfies Record<string, TransactionAdditionalStatusType>
 
 export const tsIcon = function (status: TransactionStatusType) {
   if (status === TransactionStatus.CONFIRMED) {

--- a/src/lib/live-rich-transfer-status.env.spec.ts
+++ b/src/lib/live-rich-transfer-status.env.spec.ts
@@ -422,6 +422,7 @@ async function mountTransactionStatus(transaction: Record<string, any>) {
 
 liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => {
   let restoreTxFetchInfo: (() => void) | undefined
+  const originalTxFetchInfo = new Map<string, Record<string, number> | undefined>()
 
   beforeAll(async () => {
     const passphraseHash = new Uint8Array(
@@ -484,6 +485,14 @@ liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => 
       [Cryptos.DASH]: dashTransactions[0],
       [Cryptos.ETH]: ethTransaction,
       USDT: usdtTransaction
+    }
+
+    for (const crypto of CRYPTOS_UNDER_TEST) {
+      const target = getFetchInfoTarget(crypto)
+
+      if (!originalTxFetchInfo.has(target.symbol)) {
+        originalTxFetchInfo.set(target.symbol, { ...target.txFetchInfo })
+      }
     }
 
     restoreTxFetchInfo = setShortTxFetchInfo()
@@ -569,6 +578,46 @@ liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => 
     },
     120000
   )
+
+  it('keeps live invalid new BTC rich messages pending when the real txFetchInfo is used', async () => {
+    const target = getFetchInfoTarget(Cryptos.BTC)
+    const shortTxFetchInfo = { ...target.txFetchInfo }
+    const liveTxFetchInfo = originalTxFetchInfo.get(target.symbol)
+
+    target.txFetchInfo = liveTxFetchInfo
+
+    const hash = buildFakeHash(`BTC-live-fetch-info-${Date.now()}`)
+    const transaction = await sendFraudRichMessage({
+      crypto: Cryptos.BTC,
+      hash,
+      amount: '1',
+      comments: 'live invalid new BTC with live txFetchInfo'
+    })
+
+    PendingTxStore.save(
+      Cryptos.BTC,
+      createPendingTransaction({
+        hash,
+        senderId: live.senderAddresses[Cryptos.BTC]!,
+        recipientId: live.recipientAddresses[Cryptos.BTC] || live.senderAddresses[Cryptos.BTC]!,
+        amount: 1,
+        fee: 0
+      })
+    )
+
+    const { wrapper, stop } = await mountTransactionStatus(transaction)
+
+    try {
+      await wait(4_000)
+
+      expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
+        TransactionStatus.PENDING
+      )
+    } finally {
+      stop()
+      target.txFetchInfo = shortTxFetchInfo
+    }
+  }, 120000)
 
   it.each(CRYPTOS_UNDER_TEST)(
     'marks falsified %s rich messages as INVALID with a live inconsistency reason',

--- a/src/lib/live-rich-transfer-status.env.spec.ts
+++ b/src/lib/live-rich-transfer-status.env.spec.ts
@@ -1,0 +1,701 @@
+import { createHash } from 'node:crypto'
+import { Buffer } from 'buffer'
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { computed, defineComponent, h, PropType } from 'vue'
+import { createStore } from 'vuex'
+import { QueryClient, VueQueryPlugin } from '@tanstack/vue-query'
+import { config as loadEnv } from 'dotenv'
+import BigNumber from 'bignumber.js'
+import nacl from 'tweetnacl'
+
+const TEST_PUBLIC_KEY = Buffer.from(
+  '034f355bdcb7cc0af728ef3cceb9615d90684bb5b2ca5f859ab0f0b704075871aa',
+  'hex'
+)
+
+vi.mock('tiny-secp256k1', () => ({
+  isPoint: () => true,
+  isOrderScalar: () => true,
+  pointAdd: () => new Uint8Array(33),
+  pointAddScalar: () => new Uint8Array(33),
+  pointCompress: () => new Uint8Array(33),
+  pointFromScalar: () => new Uint8Array(33),
+  pointMultiply: () => new Uint8Array(33),
+  sign: () => new Uint8Array(64),
+  verify: () => true
+}))
+
+vi.mock('ecpair', () => ({
+  ECPairFactory: () => ({
+    fromPrivateKey: () => ({
+      publicKey: TEST_PUBLIC_KEY
+    }),
+    fromPublicKey: () => ({
+      verify: () => true
+    })
+  })
+}))
+
+vi.mock('@/lib/adamant-api', () => ({
+  getTransaction: vi.fn(),
+  decodeTransaction: vi.fn((transaction) => transaction)
+}))
+vi.unmock('@/lib/nodes')
+vi.unmock('@/lib/nodes/adm/index')
+vi.unmock('@/lib/nodes/adm')
+vi.unmock('@/lib/nodes/btc-indexer/index')
+vi.unmock('@/lib/nodes/doge-indexer/index')
+vi.unmock('@/lib/nodes/eth-indexer/index')
+vi.unmock('@/lib/nodes/dash/index')
+
+import { cryptoTransferAsset } from '@/lib/adamant-api/asset'
+import { normalizeMessage } from '@/lib/chat/helpers/normalizeMessage'
+import {
+  getInconsistentStatus,
+  TransactionInconsistentReason
+} from '@/components/transactions/utils/getInconsistentStatus'
+import { useTransactionStatus } from '@/components/transactions/hooks/useTransactionStatus'
+import TransactionStatusProvider from '@/providers/TransactionProvider/TransactionStatusProvider.vue'
+import adamant from '@/lib/adamant'
+import adm from '@/lib/nodes/adm'
+import { DEFAULT_TIME_DELTA } from '@/lib/nodes/constants'
+import ethIndexer from '@/lib/nodes/eth-indexer'
+import btcIndexer from '@/lib/nodes/btc-indexer'
+import dogeIndexer from '@/lib/nodes/doge-indexer'
+import dash from '@/lib/nodes/dash'
+import { createPendingTransaction, PendingTxStore } from '@/lib/pending-transactions'
+import {
+  Cryptos,
+  CryptosInfo,
+  isErc20,
+  MessageType,
+  Transactions,
+  TransactionStatus
+} from '@/lib/constants'
+
+loadEnv({ path: '.env.local', quiet: true })
+
+const testPassphrase = process.env.ADM_TEST_ACCOUNT_PK?.trim()
+const liveDescribe = testPassphrase ? describe : describe.skip
+
+if (!process.env.CI && !testPassphrase) {
+  console.warn(
+    '\n[vitest] ADM_TEST_ACCOUNT_PK is not set — live rich transfer status tests will be skipped.\n' +
+      'To enable them, add the test account passphrase to .env.local.\n'
+  )
+}
+
+const RECIPIENT_ADM = 'U6386412615727665758'
+const TEST_FETCH_INFO = {
+  newPendingInterval: 30,
+  oldPendingInterval: 15,
+  registeredInterval: 30,
+  newPendingAttempts: 3,
+  oldPendingAttempts: 2
+}
+const CRYPTOS_UNDER_TEST = [Cryptos.BTC, Cryptos.DOGE, Cryptos.DASH, Cryptos.ETH, 'USDT'] as const
+
+const StatusHarness = defineComponent({
+  props: {
+    transaction: {
+      type: Object as PropType<Record<string, any>>,
+      required: true
+    }
+  },
+  setup(props) {
+    return () =>
+      h(
+        TransactionStatusProvider as any,
+        { transaction: props.transaction },
+        {
+          default: ({
+            status,
+            queryStatus,
+            inconsistentStatus
+          }: {
+            status: string
+            queryStatus: string
+            inconsistentStatus: string
+          }) =>
+            h('div', {
+              'data-status': status,
+              'data-query-status': queryStatus,
+              'data-inconsistent-status': inconsistentStatus
+            })
+        }
+      )
+  }
+})
+
+type CryptoUnderTest = (typeof CRYPTOS_UNDER_TEST)[number]
+const live = {
+  admAddress: '',
+  admKeypair: undefined as { publicKey: Uint8Array; privateKey: Uint8Array } | undefined,
+  recipientPublicKey: undefined as Buffer | undefined,
+  senderAddresses: {} as Record<string, string | undefined>,
+  recipientAddresses: {} as Record<string, string | undefined>,
+  realTransactions: {} as Partial<Record<CryptoUnderTest, any>>
+}
+
+function wait(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function waitFor<T>(
+  label: string,
+  read: () => T | Promise<T>,
+  predicate: (value: T) => boolean,
+  timeoutMs = 10_000
+) {
+  const startedAt = Date.now()
+  let lastValue: T | undefined
+
+  while (Date.now() - startedAt < timeoutMs) {
+    lastValue = await read()
+
+    if (predicate(lastValue)) {
+      return lastValue
+    }
+
+    await wait(50)
+  }
+
+  throw new Error(`Timed out waiting for ${label}. Last value: ${String(lastValue)}`)
+}
+
+function buildFakeHash(label: string) {
+  return createHash('sha256').update(label).digest('hex')
+}
+
+function resolveKvsMainAddress(txs: any[]) {
+  if (!Array.isArray(txs) || txs.length === 0) {
+    return undefined
+  }
+
+  const normalizedValues = txs
+    .map((tx) => tx?.asset?.state?.value)
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .map((value) => value.trim())
+
+  if (normalizedValues.length === 0) {
+    return undefined
+  }
+
+  return normalizedValues[0]
+}
+
+function markTransactionAsOld(transaction: Record<string, any>) {
+  const oldTimestamp = Date.now() - 60 * 60 * 1000
+
+  return {
+    ...transaction,
+    admTimestamp: Math.max(1, transaction.admTimestamp - 60 * 60),
+    timestamp: oldTimestamp
+  }
+}
+
+function cloneMessage<T extends Record<string, any>>(
+  transaction: T,
+  overrides: Record<string, any>
+): T {
+  return {
+    ...transaction,
+    ...overrides,
+    asset: {
+      ...transaction.asset,
+      ...overrides.asset
+    }
+  } as T
+}
+
+function getFetchInfoTarget(crypto: CryptoUnderTest) {
+  return CryptosInfo[isErc20(crypto) ? Cryptos.ETH : crypto]
+}
+
+function setShortTxFetchInfo() {
+  const originals = new Map()
+
+  for (const crypto of CRYPTOS_UNDER_TEST) {
+    const target = getFetchInfoTarget(crypto)
+
+    if (!originals.has(target.symbol)) {
+      originals.set(target.symbol, { ...target.txFetchInfo })
+      target.txFetchInfo = {
+        ...target.txFetchInfo,
+        ...TEST_FETCH_INFO
+      }
+    }
+  }
+
+  return () => {
+    for (const crypto of CRYPTOS_UNDER_TEST) {
+      const target = getFetchInfoTarget(crypto)
+      const original = originals.get(target.symbol)
+
+      if (original) {
+        target.txFetchInfo = original
+      }
+    }
+  }
+}
+
+async function fetchPublishedAddress(admAddress: string, crypto: CryptoUnderTest) {
+  const key = `${(isErc20(crypto) ? Cryptos.ETH : crypto).toLowerCase()}:address`
+  const response = await adm.get('/api/states/get', {
+    senderId: admAddress,
+    key,
+    orderBy: 'timestamp:desc',
+    limit: 20
+  })
+  const txs = response?.success ? response.transactions : []
+
+  return resolveKvsMainAddress(txs)
+}
+
+async function sendFraudRichMessage({
+  crypto,
+  hash,
+  amount,
+  comments
+}: {
+  crypto: CryptoUnderTest
+  hash: string
+  amount: string
+  comments: string
+}) {
+  const asset = cryptoTransferAsset({
+    cryptoSymbol: crypto,
+    amount,
+    hash,
+    comments
+  })
+  const encoded = adamant.encodeMessage(
+    JSON.stringify(asset),
+    live.recipientPublicKey!,
+    live.admKeypair!.privateKey
+  )
+  const timestamp = Math.floor(adamant.epochTime() - DEFAULT_TIME_DELTA)
+  const transaction = {
+    type: Transactions.CHAT_MESSAGE,
+    amount: 0,
+    senderId: live.admAddress,
+    senderPublicKey: Buffer.from(live.admKeypair!.publicKey).toString('hex'),
+    recipientId: RECIPIENT_ADM,
+    timestamp,
+    asset: {
+      chat: {
+        message: encoded.message,
+        own_message: encoded.nonce,
+        type: MessageType.RICH_CONTENT_MESSAGE
+      }
+    },
+    signature: ''
+  }
+  const transactionHash = adamant.getHash(transaction)
+  const signature = nacl.sign.detached(
+    new Uint8Array(transactionHash),
+    new Uint8Array(live.admKeypair!.privateKey)
+  )
+  transaction.signature = Buffer.from(signature).toString('hex')
+  const response = await adm.sendChatTransaction(transaction as any)
+
+  if (!response?.success || !response.transactionId) {
+    throw new Error(`Failed to send live ${crypto} rich message`)
+  }
+
+  return normalizeMessage({
+    id: response.transactionId,
+    senderId: live.admAddress,
+    recipientId: RECIPIENT_ADM,
+    timestamp: adamant.epochTime(),
+    confirmations: 0,
+    amount: 0,
+    message: asset
+  } as any)
+}
+
+function createStatusStore(transaction: Record<string, any>) {
+  return createStore({
+    state: {
+      address: live.admAddress
+    },
+    modules: {
+      partners: {
+        namespaced: true,
+        actions: {
+          fetchAddress(
+            _,
+            { crypto, partner }: { crypto: CryptoUnderTest; partner: string | undefined }
+          ) {
+            const partnerAddresses =
+              partner === live.admAddress ? live.senderAddresses : live.recipientAddresses
+
+            return partnerAddresses[crypto]
+          }
+        }
+      },
+      chat: {
+        namespaced: true,
+        state: () => ({
+          chats: {
+            [RECIPIENT_ADM]: {
+              messages: [transaction]
+            }
+          }
+        }),
+        mutations: {
+          updateCryptoTransferMessage(
+            state,
+            {
+              partnerId,
+              hash,
+              status,
+              confirmations,
+              instantlock,
+              instantlock_internal,
+              instantsend
+            }
+          ) {
+            const chat = state.chats[partnerId]
+            const message = chat?.messages.find(
+              (item: Record<string, any>) => item.hash === hash || item.id === hash
+            )
+
+            if (!message) {
+              return
+            }
+
+            if (status) message.status = status
+            if (typeof confirmations === 'number') message.confirmations = confirmations
+            if (typeof instantlock === 'boolean') message.instantlock = instantlock
+            if (typeof instantlock_internal === 'boolean') {
+              message.instantlock_internal = instantlock_internal
+            }
+            if (typeof instantsend === 'boolean') message.instantsend = instantsend
+          }
+        }
+      },
+      btc: {
+        namespaced: true,
+        state: () => ({ address: live.senderAddresses[Cryptos.BTC] })
+      },
+      doge: {
+        namespaced: true,
+        state: () => ({ address: live.senderAddresses[Cryptos.DOGE] })
+      },
+      dash: {
+        namespaced: true,
+        state: () => ({ address: live.senderAddresses[Cryptos.DASH] })
+      },
+      eth: {
+        namespaced: true,
+        state: () => ({ address: live.senderAddresses[Cryptos.ETH] })
+      }
+    }
+  })
+}
+
+async function mountTransactionStatus(transaction: Record<string, any>) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        gcTime: 0
+      }
+    }
+  })
+  const store = createStatusStore(transaction)
+  const wrapper = mount(StatusHarness, {
+    props: { transaction },
+    global: {
+      plugins: [store, [VueQueryPlugin, { queryClient }]]
+    }
+  })
+
+  const stop = () => {
+    wrapper.unmount()
+    queryClient.clear()
+  }
+
+  return { wrapper, stop }
+}
+
+liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => {
+  let restoreTxFetchInfo: (() => void) | undefined
+
+  beforeAll(async () => {
+    const passphraseHash = new Uint8Array(
+      Buffer.from(adamant.createPassphraseHash(testPassphrase!) as unknown as Uint8Array)
+    )
+    const rawAdmKeypair = adamant.makeKeypair(passphraseHash) as {
+      publicKey: Uint8Array
+      privateKey: Uint8Array
+    }
+    const admKeypair = {
+      publicKey: new Uint8Array(rawAdmKeypair.publicKey),
+      privateKey: new Uint8Array(rawAdmKeypair.privateKey)
+    }
+    live.admKeypair = admKeypair
+    live.admAddress = adamant.getAddressFromPublicKey(admKeypair.publicKey)
+    const publicKeyResponse = await adm.get('/api/accounts/getPublicKey', {
+      address: RECIPIENT_ADM
+    })
+    live.recipientPublicKey = Buffer.from(publicKeyResponse.publicKey, 'hex')
+
+    live.senderAddresses = {
+      [Cryptos.BTC]: await fetchPublishedAddress(live.admAddress, Cryptos.BTC),
+      [Cryptos.DOGE]: await fetchPublishedAddress(live.admAddress, Cryptos.DOGE),
+      [Cryptos.DASH]: await fetchPublishedAddress(live.admAddress, Cryptos.DASH),
+      [Cryptos.ETH]: await fetchPublishedAddress(live.admAddress, Cryptos.ETH),
+      USDT: await fetchPublishedAddress(live.admAddress, Cryptos.ETH)
+    }
+
+    live.recipientAddresses = {
+      [Cryptos.BTC]: await fetchPublishedAddress(RECIPIENT_ADM, Cryptos.BTC),
+      [Cryptos.DOGE]: await fetchPublishedAddress(RECIPIENT_ADM, Cryptos.DOGE),
+      [Cryptos.DASH]: await fetchPublishedAddress(RECIPIENT_ADM, Cryptos.DASH),
+      [Cryptos.ETH]: await fetchPublishedAddress(RECIPIENT_ADM, Cryptos.ETH),
+      USDT: await fetchPublishedAddress(RECIPIENT_ADM, Cryptos.ETH)
+    }
+
+    expect(live.senderAddresses[Cryptos.BTC]).toBeTruthy()
+    expect(live.senderAddresses[Cryptos.DOGE]).toBeTruthy()
+    expect(live.senderAddresses[Cryptos.DASH]).toBeTruthy()
+    expect(live.senderAddresses[Cryptos.ETH]).toBeTruthy()
+
+    const [btcTransaction] = await btcIndexer.getTransactions(live.senderAddresses[Cryptos.BTC]!)
+    const [dogeTransaction] = await dogeIndexer.getTransactions(live.senderAddresses[Cryptos.DOGE]!)
+    const dashTransactions = await dash.getTransactions(live.senderAddresses[Cryptos.DASH]!)
+    const [ethTransaction] = await ethIndexer.getTransactions({
+      address: live.senderAddresses[Cryptos.ETH]!,
+      decimals: CryptosInfo.ETH.decimals,
+      limit: 1
+    })
+    const [usdtTransaction] = await ethIndexer.getTransactions({
+      address: live.senderAddresses[Cryptos.ETH]!,
+      contract: (CryptosInfo.USDT as any).contractId,
+      decimals: CryptosInfo.USDT.decimals,
+      limit: 1
+    })
+
+    live.realTransactions = {
+      [Cryptos.BTC]: btcTransaction,
+      [Cryptos.DOGE]: dogeTransaction,
+      [Cryptos.DASH]: dashTransactions[0],
+      [Cryptos.ETH]: ethTransaction,
+      USDT: usdtTransaction
+    }
+
+    restoreTxFetchInfo = setShortTxFetchInfo()
+  }, 120000)
+
+  afterEach(() => {
+    PendingTxStore.clear()
+  })
+
+  afterAll(() => {
+    restoreTxFetchInfo?.()
+    PendingTxStore.clear()
+  })
+
+  it.each(CRYPTOS_UNDER_TEST)(
+    'marks old invalid %s rich messages as REJECTED after exhausting txFetchInfo retries',
+    async (crypto) => {
+      const transaction = await sendFraudRichMessage({
+        crypto,
+        hash: buildFakeHash(`${crypto}-old-${Date.now()}`),
+        amount: '1',
+        comments: `live invalid old ${crypto}`
+      })
+      const oldTransaction = markTransactionAsOld(transaction)
+      const { wrapper, stop } = await mountTransactionStatus(oldTransaction)
+
+      try {
+        await waitFor(
+          `${crypto} old status`,
+          () => wrapper.find('[data-status]').attributes('data-status'),
+          (value) => value === TransactionStatus.REJECTED,
+          10_000
+        )
+
+        expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
+          TransactionStatus.REJECTED
+        )
+      } finally {
+        stop()
+      }
+    },
+    120000
+  )
+
+  it.each(CRYPTOS_UNDER_TEST)(
+    'marks new invalid %s rich messages as REJECTED when locally tracked as pending',
+    async (crypto) => {
+      const hash = buildFakeHash(`${crypto}-new-${Date.now()}`)
+      const transaction = await sendFraudRichMessage({
+        crypto,
+        hash,
+        amount: '1',
+        comments: `live invalid new ${crypto}`
+      })
+
+      PendingTxStore.save(
+        crypto,
+        createPendingTransaction({
+          hash,
+          senderId: live.senderAddresses[crypto]!,
+          recipientId: live.recipientAddresses[crypto] || live.senderAddresses[crypto]!,
+          amount: 1,
+          fee: 0
+        })
+      )
+
+      const { wrapper, stop } = await mountTransactionStatus(transaction)
+
+      try {
+        await waitFor(
+          `${crypto} new status`,
+          () => wrapper.find('[data-status]').attributes('data-status'),
+          (value) => value === TransactionStatus.REJECTED,
+          10_000
+        )
+
+        expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
+          TransactionStatus.REJECTED
+        )
+      } finally {
+        stop()
+      }
+    },
+    120000
+  )
+
+  it.each(CRYPTOS_UNDER_TEST)(
+    'marks falsified %s rich messages as INVALID with a live inconsistency reason',
+    async (crypto) => {
+      const liveTransaction = live.realTransactions[crypto]
+
+      expect(
+        liveTransaction,
+        `No live ${crypto} transaction found for inconsistency test`
+      ).toBeTruthy()
+      const fakeAmount = new BigNumber(liveTransaction!.amount).times(1.02).toFixed()
+
+      const admMessage = await sendFraudRichMessage({
+        crypto,
+        hash: liveTransaction!.hash,
+        amount: fakeAmount,
+        comments: `live inconsistent ${crypto}`
+      })
+      const { wrapper, stop } = await mountTransactionStatus(admMessage)
+
+      try {
+        await waitFor(
+          `${crypto} invalid status`,
+          () => wrapper.find('[data-status]').attributes('data-status'),
+          (value) => value === TransactionStatus.INVALID,
+          20_000
+        )
+
+        expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
+          TransactionStatus.INVALID
+        )
+        expect(wrapper.find('[data-status]').attributes('data-inconsistent-status')).toBe(
+          TransactionInconsistentReason.WRONG_AMOUNT
+        )
+      } finally {
+        stop()
+      }
+    },
+    120000
+  )
+
+  it.each(CRYPTOS_UNDER_TEST)(
+    'detects live inconsistency reasons for %s based on real chain transactions',
+    async (crypto) => {
+      const liveTransaction = live.realTransactions[crypto]
+
+      expect(
+        liveTransaction,
+        `No live ${crypto} transaction found for inconsistency reason matrix`
+      ).toBeTruthy()
+
+      const admMessage = await sendFraudRichMessage({
+        crypto,
+        hash: liveTransaction!.hash,
+        amount: new BigNumber(liveTransaction!.amount).toFixed(),
+        comments: `live reason matrix ${crypto}`
+      })
+      const consistentAddresses = {
+        senderCryptoAddress: liveTransaction!.senderId,
+        recipientCryptoAddress: liveTransaction!.recipientId
+      }
+      const wrongTimestampMessage = cloneMessage(admMessage, {
+        timestamp:
+          liveTransaction!.timestamp +
+          (CryptosInfo[isErc20(crypto) ? Cryptos.ETH : crypto].txConsistencyMaxTime || 0) +
+          60_000
+      })
+      const derivedWrongAmount = useTransactionStatus(
+        computed(() => false),
+        computed(() => 'success' as const),
+        computed(() => liveTransaction!.status as any),
+        computed(() =>
+          getInconsistentStatus(
+            liveTransaction!,
+            cloneMessage(admMessage, {
+              amount: new BigNumber(liveTransaction!.amount).times(1.02).toFixed()
+            }),
+            consistentAddresses
+          )
+        )
+      )
+
+      expect(
+        getInconsistentStatus(
+          liveTransaction!,
+          cloneMessage(admMessage, { hash: buildFakeHash(`${crypto}-wrong-hash`) }),
+          consistentAddresses
+        )
+      ).toBe(TransactionInconsistentReason.WRONG_TX_HASH)
+      expect(
+        getInconsistentStatus(liveTransaction!, admMessage, {
+          senderCryptoAddress: undefined,
+          recipientCryptoAddress: liveTransaction!.recipientId
+        })
+      ).toBe(TransactionInconsistentReason.NO_SENDER_CRYPTO_ADDRESS)
+      expect(
+        getInconsistentStatus(liveTransaction!, admMessage, {
+          senderCryptoAddress: liveTransaction!.senderId,
+          recipientCryptoAddress: undefined
+        })
+      ).toBe(TransactionInconsistentReason.NO_RECIPIENT_CRYPTO_ADDRESS)
+      expect(
+        getInconsistentStatus(liveTransaction!, admMessage, {
+          senderCryptoAddress: buildFakeHash(`${crypto}-wrong-sender`),
+          recipientCryptoAddress: liveTransaction!.recipientId
+        })
+      ).toBe(TransactionInconsistentReason.SENDER_CRYPTO_ADDRESS_MISMATCH)
+      expect(
+        getInconsistentStatus(liveTransaction!, admMessage, {
+          senderCryptoAddress: liveTransaction!.senderId,
+          recipientCryptoAddress: buildFakeHash(`${crypto}-wrong-recipient`)
+        })
+      ).toBe(TransactionInconsistentReason.RECIPIENT_CRYPTO_ADDRESS_MISMATCH)
+      expect(
+        getInconsistentStatus(
+          liveTransaction!,
+          cloneMessage(admMessage, {
+            amount: new BigNumber(liveTransaction!.amount).times(1.02).toFixed()
+          }),
+          consistentAddresses
+        )
+      ).toBe(TransactionInconsistentReason.WRONG_AMOUNT)
+      expect(derivedWrongAmount.value).toBe(TransactionStatus.INVALID)
+      expect(
+        getInconsistentStatus(liveTransaction!, wrongTimestampMessage, consistentAddresses)
+      ).toBe(TransactionInconsistentReason.WRONG_TIMESTAMP)
+    },
+    120000
+  )
+})

--- a/src/lib/live-rich-transfer-status.env.spec.ts
+++ b/src/lib/live-rich-transfer-status.env.spec.ts
@@ -524,7 +524,7 @@ liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => 
           `${crypto} old status`,
           () => wrapper.find('[data-status]').attributes('data-status'),
           (value) => value === TransactionStatus.REJECTED,
-          10_000
+          30_000
         )
 
         expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
@@ -566,7 +566,7 @@ liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => 
           `${crypto} new status`,
           () => wrapper.find('[data-status]').attributes('data-status'),
           (value) => value === TransactionStatus.REJECTED,
-          10_000
+          30_000
         )
 
         expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
@@ -643,7 +643,7 @@ liveDescribe('live rich transfer status checks from ADM_TEST_ACCOUNT_PK', () => 
           `${crypto} invalid status`,
           () => wrapper.find('[data-status]').attributes('data-status'),
           (value) => value === TransactionStatus.INVALID,
-          20_000
+          60_000
         )
 
         expect(wrapper.find('[data-status]').attributes('data-status')).toBe(

--- a/src/lib/live-send-builders.env.spec.js
+++ b/src/lib/live-send-builders.env.spec.js
@@ -100,6 +100,26 @@ function decodeOutputs(hex, network) {
   }))
 }
 
+function calculateUtxoFee(hex, unspents) {
+  const transaction = bitcoin.Transaction.fromHex(hex)
+  const totalIn = transaction.ins.reduce((sum, input) => {
+    const txid = Buffer.from(input.hash).reverse().toString('hex')
+    const utxo = unspents.find((item) => item.txid === txid && item.vout === input.index)
+
+    if (!utxo) {
+      throw new Error(`Missing UTXO for ${txid}:${input.index}`)
+    }
+
+    return sum.plus(utxo.amount)
+  }, new BigNumber(0))
+  const totalOut = transaction.outs.reduce(
+    (sum, output) => sum.plus(output.value.toString()),
+    new BigNumber(0)
+  )
+
+  return totalIn.minus(totalOut).div(SATOSHI_MULTIPLIER).toNumber()
+}
+
 function solveMaxSendable(balance, feeCalculator, decimals) {
   let amount = new BigNumber(balance)
 
@@ -423,6 +443,7 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
 
         expect(validateAddress(Cryptos.BTC, recipient)).toBe(true)
         expect(transaction.txid).toMatch(/^[0-9a-f]{64}$/)
+        expect(calculateUtxoFee(transaction.hex, live.btc.unspents)).toBe(fee)
         expect(outputs[0]).toEqual({ address: recipient, value: toSmallestUnit(amount) })
 
         restore()
@@ -446,6 +467,8 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
 
       expect(new BigNumber(live.btc.balance).toNumber()).toBeGreaterThan(Number(amount) + feeOn)
       expect(feeOn).toBeGreaterThan(feeOff)
+      expect(calculateUtxoFee(txOff.hex, live.btc.unspents)).toBe(feeOff)
+      expect(calculateUtxoFee(txOn.hex, live.btc.unspents)).toBe(feeOn)
       expect(outputsOff[0].value).toBe(toSmallestUnit(amount))
       expect(outputsOn[0].value).toBe(toSmallestUnit(amount))
 
@@ -460,6 +483,7 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
       const outputs = decodeOutputs(transaction.hex, networks[Cryptos.BTC])
 
       expect(new BigNumber(amount).toNumber()).toBeGreaterThanOrEqual(getMinAmount(Cryptos.BTC))
+      expect(calculateUtxoFee(transaction.hex, live.btc.unspents)).toBe(fee)
       expect(outputs[0].value).toBe(toSmallestUnit(amount))
 
       restore()
@@ -496,6 +520,7 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
         const outputs = decodeOutputs(transaction.hex, networks[Cryptos.DOGE])
 
         expect(validateAddress(Cryptos.DOGE, recipient)).toBe(true)
+        expect(calculateUtxoFee(transaction.hex, live.doge.unspents)).toBe(fee)
         expect(outputs[0].value).toBe(toSmallestUnit(amount))
 
         restore()
@@ -517,6 +542,8 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
       const halfTx = await live.doge.api.createTransaction(DOGE_RECIPIENTS.p2pkh, halfAmount, fee)
       const fullTx = await live.doge.api.createTransaction(DOGE_RECIPIENTS.p2sh, fullAmount, fee)
 
+      expect(calculateUtxoFee(halfTx.hex, live.doge.unspents)).toBe(fee)
+      expect(calculateUtxoFee(fullTx.hex, live.doge.unspents)).toBe(fee)
       expect(decodeOutputs(halfTx.hex, networks[Cryptos.DOGE])[0].value).toBe(
         toSmallestUnit(halfAmount)
       )
@@ -553,6 +580,7 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
         const outputs = decodeOutputs(transaction.hex, networks[Cryptos.DASH])
 
         expect(validateAddress(Cryptos.DASH, recipient)).toBe(true)
+        expect(calculateUtxoFee(transaction.hex, live.dash.unspents)).toBe(fee)
         expect(outputs[0].value).toBe(toSmallestUnit(amount))
 
         restore()
@@ -574,6 +602,8 @@ liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
       const halfTx = await live.dash.api.createTransaction(DASH_RECIPIENTS.p2pkh, halfAmount, fee)
       const fullTx = await live.dash.api.createTransaction(DASH_RECIPIENTS.p2sh, fullAmount, fee)
 
+      expect(calculateUtxoFee(halfTx.hex, live.dash.unspents)).toBe(fee)
+      expect(calculateUtxoFee(fullTx.hex, live.dash.unspents)).toBe(fee)
       expect(decodeOutputs(halfTx.hex, networks[Cryptos.DASH])[0].value).toBe(
         toSmallestUnit(halfAmount)
       )

--- a/src/lib/live-send-builders.env.spec.js
+++ b/src/lib/live-send-builders.env.spec.js
@@ -1,0 +1,783 @@
+// @vitest-environment node
+
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+import { config as loadEnv } from 'dotenv'
+import BigNumber from 'bignumber.js'
+import * as bitcoin from 'bitcoinjs-lib'
+import EthContract from 'web3-eth-contract'
+import { signTransaction, TransactionFactory } from 'web3-eth-accounts'
+
+vi.hoisted(() => {
+  const storage = new Map()
+  const localStorage = {
+    getItem: (key) => storage.get(key) ?? null,
+    setItem: (key, value) => storage.set(key, String(value)),
+    removeItem: (key) => storage.delete(key),
+    clear: () => storage.clear()
+  }
+
+  globalThis.window = {
+    localStorage
+  }
+  globalThis.localStorage = localStorage
+  globalThis.location = {
+    protocol: 'https:'
+  }
+  Object.defineProperty(globalThis, 'navigator', {
+    value: { onLine: true },
+    configurable: true
+  })
+})
+
+vi.unmock('@/lib/nodes')
+vi.unmock('@/lib/nodes/adm/index')
+vi.unmock('@/lib/nodes/eth/index')
+vi.unmock('@/lib/nodes/btc-indexer/index')
+
+import adamant from '@/lib/adamant'
+import BitcoinApi from '@/lib/bitcoin/bitcoin-api'
+import DogeApi from '@/lib/bitcoin/doge-api'
+import DashApi from '@/lib/bitcoin/dash-api'
+import networks from '@/lib/bitcoin/networks'
+import validateAddress from '@/lib/validateAddress'
+import btcGetters from '@/store/modules/btc/btc-getters'
+import eth from '@/lib/nodes/eth'
+import adm from '@/lib/nodes/adm'
+import { getAccountFromPassphrase, calculateReliableValue, calculateFee } from '@/lib/eth-utils'
+import Erc20 from '@/store/modules/erc20/erc20.abi.json'
+import { Cryptos, CryptosInfo, Fees, Transactions, getMinAmount } from '@/lib/constants'
+
+loadEnv({ path: '.env.local', quiet: true })
+
+const testPassphrase = process.env.ADM_TEST_ACCOUNT_PK?.trim()
+const liveDescribe = testPassphrase ? describe : describe.skip
+
+if (!process.env.CI && !testPassphrase) {
+  console.warn(
+    '\n[vitest] ADM_TEST_ACCOUNT_PK is not set — live wallet build tests will be skipped.\n' +
+      'To enable them, add the test account passphrase to .env.local.\n'
+  )
+}
+
+const ADM_RECIPIENT = 'U12345678901234567890'
+const ETH_RECIPIENT = '0x000000000000000000000000000000000000dEaD'
+const BTC_RECIPIENTS = {
+  p2pkh: '1Q1pE5vPGEEMqRcVRMbtBK842Y6Pzo6nK9',
+  p2sh: '3PFpzMLrKWsphFtc8BesF3MGPnimKMuF4x',
+  p2wpkh: 'bc1ql3e9pgs3mmwuwrh95fecme0s0qtn2880lsvsd5'
+}
+const DOGE_RECIPIENTS = {
+  p2pkh: 'DU9umLs2Ze8eNRo69wbSj5HeufphJawFPh',
+  p2sh: 'ABhQshCgMtU4f7g6Uqr51Tjv96HMQKRDFq'
+}
+const DASH_RECIPIENTS = {
+  p2pkh: 'Xyhf4LaHDwSwzND5HEv72qoqrsg625rCMt',
+  p2sh: '7mfny3Qx6ogokWqaLKrA6i7CN4jh9dsPqy'
+}
+const INVALID_ADDRESS = 'not-a-valid-address'
+const SATOSHI_MULTIPLIER = 1e8
+
+function decimalPlacesFor(crypto) {
+  return CryptosInfo[crypto].cryptoTransferDecimals
+}
+
+function toFixedAmount(value, decimals = 8) {
+  return new BigNumber(value).decimalPlaces(decimals, BigNumber.ROUND_DOWN).toFixed()
+}
+
+function toSmallestUnit(amount, multiplier = SATOSHI_MULTIPLIER) {
+  return BigInt(
+    new BigNumber(amount).times(multiplier).integerValue(BigNumber.ROUND_DOWN).toFixed(0)
+  )
+}
+
+function decodeOutputs(hex, network) {
+  const transaction = bitcoin.Transaction.fromHex(hex)
+
+  return transaction.outs.map((output) => ({
+    address: bitcoin.address.fromOutputScript(output.script, network),
+    value: output.value
+  }))
+}
+
+function solveMaxSendable(balance, feeCalculator, decimals) {
+  let amount = new BigNumber(balance)
+
+  for (let i = 0; i < 12; i++) {
+    const fee = new BigNumber(feeCalculator(amount.toFixed()))
+    amount = new BigNumber(balance).minus(fee)
+  }
+
+  return amount.decimalPlaces(decimals, BigNumber.ROUND_DOWN).toFixed()
+}
+
+async function fetchLiveUnspents(api) {
+  const unspents = await api.getUnspents()
+
+  return Promise.all(
+    unspents.map(async (unspent) => ({
+      ...unspent,
+      txHex: await api.getTransactionHex(unspent.txid)
+    }))
+  )
+}
+
+function useCachedUnspents(api, cachedUnspents) {
+  const txHexById = new Map(cachedUnspents.map((unspent) => [unspent.txid, unspent.txHex]))
+  const getUnspentsSpy = vi
+    .spyOn(api, 'getUnspents')
+    .mockResolvedValue(cachedUnspents.map(({ txHex: _txHex, ...rest }) => ({ ...rest })))
+  const getTransactionHexSpy = vi
+    .spyOn(api, 'getTransactionHex')
+    .mockImplementation(async (txid) => txHexById.get(txid))
+
+  return () => {
+    getUnspentsSpy.mockRestore()
+    getTransactionHexSpy.mockRestore()
+  }
+}
+
+function createAdmTransfer({ keypair, senderId, recipientId, amount }) {
+  const transaction = {
+    type: Transactions.SEND,
+    amount: adamant.prepareAmount(amount),
+    senderId,
+    recipientId,
+    senderPublicKey: Buffer.from(keypair.publicKey).toString('hex')
+  }
+
+  transaction.timestamp = adamant.epochTime()
+  transaction.signature = Buffer.from(adamant.transactionSign(transaction, keypair)).toString('hex')
+
+  return transaction
+}
+
+async function buildEthTransfer({
+  client,
+  account,
+  recipient,
+  amount,
+  increaseFee,
+  gasPriceWei,
+  nonce
+}) {
+  const ethInfo = CryptosInfo.ETH
+  const gasPrice = calculateReliableValue(
+    gasPriceWei.toString(),
+    ethInfo.reliabilityGasPricePercent,
+    increaseFee,
+    ethInfo.increasedGasPricePercent
+  )
+    .integerValue()
+    .toFixed(0)
+
+  const transaction = {
+    from: account.address,
+    to: recipient,
+    value: toSmallestUnit(amount, 1e18),
+    gasPrice: BigInt(gasPrice),
+    nonce
+  }
+
+  const estimatedGas = await client.estimateGas(transaction)
+  const gasLimit = calculateReliableValue(estimatedGas, ethInfo.reliabilityGasLimitPercent)
+    .integerValue()
+    .toFixed(0)
+  transaction.gasLimit = BigInt(gasLimit)
+
+  const signed = await signTransaction(
+    TransactionFactory.fromTxData(transaction),
+    account.privateKey
+  )
+
+  return {
+    transaction,
+    signed,
+    feeEth: calculateFee(transaction.gasLimit.toString(), transaction.gasPrice.toString())
+  }
+}
+
+async function buildUsdtTransfer({
+  client,
+  account,
+  recipient,
+  amount,
+  increaseFee,
+  gasPriceWei,
+  nonce,
+  contractAddress,
+  decimals
+}) {
+  const ethInfo = CryptosInfo.ETH
+  const tokenInfo = CryptosInfo.USDT
+  const contract = new EthContract(Erc20, contractAddress)
+
+  const gasPrice = calculateReliableValue(
+    gasPriceWei.toString(),
+    tokenInfo.reliabilityGasPricePercent ?? ethInfo.reliabilityGasPricePercent,
+    increaseFee,
+    tokenInfo.increasedGasPricePercent ?? ethInfo.increasedGasPricePercent
+  )
+    .integerValue()
+    .toFixed(0)
+
+  const amountWhole = new BigNumber(amount)
+    .times(new BigNumber(10).pow(decimals))
+    .integerValue(BigNumber.ROUND_DOWN)
+    .toFixed(0)
+
+  const transaction = {
+    from: account.address,
+    to: contractAddress,
+    value: '0x0',
+    gasPrice: BigInt(gasPrice),
+    nonce,
+    data: contract.methods.transfer(recipient, amountWhole).encodeABI()
+  }
+
+  const estimatedGas = await client.estimateGas(transaction)
+  const gasLimit = calculateReliableValue(
+    estimatedGas,
+    tokenInfo.reliabilityGasLimitPercent ?? ethInfo.reliabilityGasLimitPercent
+  )
+    .integerValue()
+    .toFixed(0)
+  transaction.gasLimit = BigInt(gasLimit)
+
+  const signed = await signTransaction(
+    TransactionFactory.fromTxData(transaction),
+    account.privateKey
+  )
+
+  return {
+    transaction,
+    signed,
+    feeEth: calculateFee(transaction.gasLimit.toString(), transaction.gasPrice.toString())
+  }
+}
+
+liveDescribe('live no-broadcast send builders from ADM_TEST_ACCOUNT_PK', () => {
+  const live = {
+    adm: {},
+    btc: {},
+    doge: {},
+    dash: {},
+    eth: {},
+    usdt: {}
+  }
+
+  beforeAll(async () => {
+    const admHash = adamant.createPassphraseHash(testPassphrase)
+    const admKeypair = adamant.makeKeypair(admHash)
+    const admAddress = adamant.getAddressFromPublicKey(admKeypair.publicKey)
+    const admAccount = await adm.get('/api/accounts', {
+      publicKey: Buffer.from(admKeypair.publicKey).toString('hex')
+    })
+
+    expect(admAccount.success).toBe(true)
+    live.adm = {
+      keypair: admKeypair,
+      address: admAddress,
+      balance: Number(adamant.toAdm(admAccount.account.balance))
+    }
+
+    const btcApi = new BitcoinApi(testPassphrase)
+    const btcBalance = await btcApi.getBalance()
+    const btcFeeRate = await btcApi.getFeeRate()
+    const btcUnspents = await fetchLiveUnspents(btcApi)
+    live.btc = {
+      api: btcApi,
+      balance: btcBalance,
+      feeRate: btcFeeRate,
+      unspents: btcUnspents
+    }
+
+    const dogeApi = new DogeApi(testPassphrase)
+    const dogeBalance = await dogeApi.getBalance()
+    const dogeFeePerByte = await dogeApi.getFeePerByte()
+    const dogeUnspents = await fetchLiveUnspents(dogeApi)
+    live.doge = {
+      api: dogeApi,
+      balance: dogeBalance,
+      feePerByte: dogeFeePerByte,
+      unspents: dogeUnspents
+    }
+
+    const dashApi = new DashApi(testPassphrase)
+    const dashBalance = await dashApi.getBalance()
+    const dashUnspents = await fetchLiveUnspents(dashApi)
+    live.dash = {
+      api: dashApi,
+      balance: dashBalance,
+      unspents: dashUnspents
+    }
+
+    const ethAccount = getAccountFromPassphrase(testPassphrase, eth)
+    const ethClient = eth.getClient()
+    const ethBalanceWei = await ethClient.getBalance(ethAccount.address, 'latest')
+    const gasPriceWei = await ethClient.getGasPrice()
+    const nonce = await ethClient.getTransactionCount(ethAccount.address)
+
+    const usdtContract = new EthContract(Erc20, CryptosInfo.USDT.contractId)
+    usdtContract.setProvider(ethClient.provider)
+    const usdtBalanceRaw = await usdtContract.methods.balanceOf(ethAccount.address).call()
+
+    live.eth = {
+      account: ethAccount,
+      client: ethClient,
+      balanceEth: new BigNumber(ethBalanceWei.toString()).div(1e18).toFixed(),
+      gasPriceWei: BigInt(gasPriceWei.toString()),
+      nonce: BigInt(nonce.toString())
+    }
+    live.usdt = {
+      contractAddress: CryptosInfo.USDT.contractId,
+      decimals: CryptosInfo.USDT.decimals,
+      balance: new BigNumber(usdtBalanceRaw.toString())
+        .div(new BigNumber(10).pow(CryptosInfo.USDT.decimals))
+        .toFixed()
+    }
+  }, 120000)
+
+  describe('ADM', () => {
+    it('builds a minTransferAmount ADM transaction from the real test account', () => {
+      const amount = getMinAmount(Cryptos.ADM)
+      expect(live.adm.balance).toBeGreaterThan(amount + Fees.ADM_TRANSFER)
+
+      const transaction = createAdmTransfer({
+        keypair: live.adm.keypair,
+        senderId: live.adm.address,
+        recipientId: ADM_RECIPIENT,
+        amount
+      })
+
+      expect(transaction.amount).toBe(adamant.prepareAmount(amount))
+      expect(transaction.senderId).toBe(live.adm.address)
+      expect(transaction.recipientId).toBe(ADM_RECIPIENT)
+      expect(transaction.signature).toMatch(/^[0-9a-f]+$/)
+    })
+
+    it('builds a 50% ADM balance transaction from the real test account', () => {
+      const amount = toFixedAmount(
+        new BigNumber(live.adm.balance).div(2),
+        decimalPlacesFor(Cryptos.ADM)
+      )
+      expect(live.adm.balance).toBeGreaterThan(
+        new BigNumber(amount).plus(Fees.ADM_TRANSFER).toNumber()
+      )
+
+      const transaction = createAdmTransfer({
+        keypair: live.adm.keypair,
+        senderId: live.adm.address,
+        recipientId: ADM_RECIPIENT,
+        amount
+      })
+
+      expect(transaction.amount).toBe(adamant.prepareAmount(amount))
+    })
+
+    it('builds a 100% ADM spendable balance transaction with fee reserved', () => {
+      const amount = toFixedAmount(
+        new BigNumber(live.adm.balance).minus(Fees.ADM_TRANSFER),
+        decimalPlacesFor(Cryptos.ADM)
+      )
+      expect(new BigNumber(amount).toNumber()).toBeGreaterThanOrEqual(getMinAmount(Cryptos.ADM))
+
+      const transaction = createAdmTransfer({
+        keypair: live.adm.keypair,
+        senderId: live.adm.address,
+        recipientId: ADM_RECIPIENT,
+        amount
+      })
+
+      expect(transaction.amount).toBe(adamant.prepareAmount(amount))
+    })
+
+    it('rejects invalid ADM recipient parameters at validation stage', () => {
+      expect(validateAddress(Cryptos.ADM, INVALID_ADDRESS)).toBe(false)
+    })
+  })
+
+  describe('BTC', () => {
+    const feeForAmount = (amount, increaseFee) =>
+      Number(
+        btcGetters.fee({ utxo: live.btc.unspents, feeRate: live.btc.feeRate })(
+          amount,
+          '',
+          '',
+          false,
+          increaseFee
+        )
+      )
+
+    it.each(Object.entries(BTC_RECIPIENTS))(
+      'builds a minTransferAmount BTC transaction to %s using live UTXO and fee data',
+      async (_label, recipient) => {
+        const restore = useCachedUnspents(live.btc.api, live.btc.unspents)
+        const amount = getMinAmount(Cryptos.BTC)
+        const fee = feeForAmount(amount, false)
+
+        expect(live.btc.balance).toBeGreaterThan(amount + fee)
+
+        const transaction = await live.btc.api.createTransaction(recipient, amount, fee)
+        const outputs = decodeOutputs(transaction.hex, networks[Cryptos.BTC])
+
+        expect(validateAddress(Cryptos.BTC, recipient)).toBe(true)
+        expect(transaction.txid).toMatch(/^[0-9a-f]{64}$/)
+        expect(outputs[0]).toEqual({ address: recipient, value: toSmallestUnit(amount) })
+
+        restore()
+      },
+      120000
+    )
+
+    it('builds 50% BTC balance transactions with Increase fee off and on', async () => {
+      const restore = useCachedUnspents(live.btc.api, live.btc.unspents)
+      const amount = toFixedAmount(
+        new BigNumber(live.btc.balance).div(2),
+        decimalPlacesFor(Cryptos.BTC)
+      )
+      const feeOff = feeForAmount(amount, false)
+      const feeOn = feeForAmount(amount, true)
+
+      const txOff = await live.btc.api.createTransaction(BTC_RECIPIENTS.p2wpkh, amount, feeOff)
+      const txOn = await live.btc.api.createTransaction(BTC_RECIPIENTS.p2wpkh, amount, feeOn)
+      const outputsOff = decodeOutputs(txOff.hex, networks[Cryptos.BTC])
+      const outputsOn = decodeOutputs(txOn.hex, networks[Cryptos.BTC])
+
+      expect(new BigNumber(live.btc.balance).toNumber()).toBeGreaterThan(Number(amount) + feeOn)
+      expect(feeOn).toBeGreaterThan(feeOff)
+      expect(outputsOff[0].value).toBe(toSmallestUnit(amount))
+      expect(outputsOn[0].value).toBe(toSmallestUnit(amount))
+
+      restore()
+    }, 120000)
+
+    it('builds a 100% BTC spendable balance transaction with live fee reserved', async () => {
+      const restore = useCachedUnspents(live.btc.api, live.btc.unspents)
+      const amount = solveMaxSendable(live.btc.balance, (value) => feeForAmount(value, false), 8)
+      const fee = feeForAmount(amount, false)
+      const transaction = await live.btc.api.createTransaction(BTC_RECIPIENTS.p2pkh, amount, fee)
+      const outputs = decodeOutputs(transaction.hex, networks[Cryptos.BTC])
+
+      expect(new BigNumber(amount).toNumber()).toBeGreaterThanOrEqual(getMinAmount(Cryptos.BTC))
+      expect(outputs[0].value).toBe(toSmallestUnit(amount))
+
+      restore()
+    }, 120000)
+
+    it('throws on invalid BTC recipient parameters without broadcasting', async () => {
+      const restore = useCachedUnspents(live.btc.api, live.btc.unspents)
+
+      await expect(
+        live.btc.api.createTransaction(
+          INVALID_ADDRESS,
+          getMinAmount(Cryptos.BTC),
+          feeForAmount(getMinAmount(Cryptos.BTC), false)
+        )
+      ).rejects.toThrow()
+
+      restore()
+    }, 120000)
+  })
+
+  describe('DOGE', () => {
+    const fee = CryptosInfo.DOGE.fixedFee
+
+    it.each(Object.entries(DOGE_RECIPIENTS))(
+      'builds a minTransferAmount DOGE transaction to %s using live node data',
+      async (_label, recipient) => {
+        const restore = useCachedUnspents(live.doge.api, live.doge.unspents)
+        const amount = getMinAmount(Cryptos.DOGE)
+
+        expect(live.doge.feePerByte).toBeGreaterThan(0)
+        expect(live.doge.balance).toBeGreaterThan(amount + fee)
+
+        const transaction = await live.doge.api.createTransaction(recipient, amount, fee)
+        const outputs = decodeOutputs(transaction.hex, networks[Cryptos.DOGE])
+
+        expect(validateAddress(Cryptos.DOGE, recipient)).toBe(true)
+        expect(outputs[0].value).toBe(toSmallestUnit(amount))
+
+        restore()
+      },
+      120000
+    )
+
+    it('builds 50% and 100% spendable DOGE transactions from live wallet state', async () => {
+      const restore = useCachedUnspents(live.doge.api, live.doge.unspents)
+      const halfAmount = toFixedAmount(
+        new BigNumber(live.doge.balance).div(2),
+        decimalPlacesFor(Cryptos.DOGE)
+      )
+      const fullAmount = toFixedAmount(
+        new BigNumber(live.doge.balance).minus(fee),
+        decimalPlacesFor(Cryptos.DOGE)
+      )
+
+      const halfTx = await live.doge.api.createTransaction(DOGE_RECIPIENTS.p2pkh, halfAmount, fee)
+      const fullTx = await live.doge.api.createTransaction(DOGE_RECIPIENTS.p2sh, fullAmount, fee)
+
+      expect(decodeOutputs(halfTx.hex, networks[Cryptos.DOGE])[0].value).toBe(
+        toSmallestUnit(halfAmount)
+      )
+      expect(decodeOutputs(fullTx.hex, networks[Cryptos.DOGE])[0].value).toBe(
+        toSmallestUnit(fullAmount)
+      )
+
+      restore()
+    }, 120000)
+
+    it('throws on invalid DOGE recipient parameters without broadcasting', async () => {
+      const restore = useCachedUnspents(live.doge.api, live.doge.unspents)
+
+      await expect(
+        live.doge.api.createTransaction(INVALID_ADDRESS, getMinAmount(Cryptos.DOGE), fee)
+      ).rejects.toThrow()
+
+      restore()
+    }, 120000)
+  })
+
+  describe('DASH', () => {
+    const fee = CryptosInfo.DASH.fixedFee
+
+    it.each(Object.entries(DASH_RECIPIENTS))(
+      'builds a minTransferAmount DASH transaction to %s using live node data',
+      async (_label, recipient) => {
+        const restore = useCachedUnspents(live.dash.api, live.dash.unspents)
+        const amount = getMinAmount(Cryptos.DASH)
+
+        expect(live.dash.balance).toBeGreaterThan(amount + fee)
+
+        const transaction = await live.dash.api.createTransaction(recipient, amount, fee)
+        const outputs = decodeOutputs(transaction.hex, networks[Cryptos.DASH])
+
+        expect(validateAddress(Cryptos.DASH, recipient)).toBe(true)
+        expect(outputs[0].value).toBe(toSmallestUnit(amount))
+
+        restore()
+      },
+      120000
+    )
+
+    it('builds 50% and 100% spendable DASH transactions from live wallet state', async () => {
+      const restore = useCachedUnspents(live.dash.api, live.dash.unspents)
+      const halfAmount = toFixedAmount(
+        new BigNumber(live.dash.balance).div(2),
+        decimalPlacesFor(Cryptos.DASH)
+      )
+      const fullAmount = toFixedAmount(
+        new BigNumber(live.dash.balance).minus(fee),
+        decimalPlacesFor(Cryptos.DASH)
+      )
+
+      const halfTx = await live.dash.api.createTransaction(DASH_RECIPIENTS.p2pkh, halfAmount, fee)
+      const fullTx = await live.dash.api.createTransaction(DASH_RECIPIENTS.p2sh, fullAmount, fee)
+
+      expect(decodeOutputs(halfTx.hex, networks[Cryptos.DASH])[0].value).toBe(
+        toSmallestUnit(halfAmount)
+      )
+      expect(decodeOutputs(fullTx.hex, networks[Cryptos.DASH])[0].value).toBe(
+        toSmallestUnit(fullAmount)
+      )
+
+      restore()
+    }, 120000)
+
+    it('throws on invalid DASH recipient parameters without broadcasting', async () => {
+      const restore = useCachedUnspents(live.dash.api, live.dash.unspents)
+
+      await expect(
+        live.dash.api.createTransaction(INVALID_ADDRESS, getMinAmount(Cryptos.DASH), fee)
+      ).rejects.toThrow()
+
+      restore()
+    }, 120000)
+  })
+
+  describe('ETH', () => {
+    it('builds a minTransferAmount ETH transaction from live balance and gas data', async () => {
+      const amount = getMinAmount(Cryptos.ETH)
+      const { transaction, signed, feeEth } = await buildEthTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce
+      })
+
+      expect(new BigNumber(live.eth.balanceEth).toNumber()).toBeGreaterThan(amount + Number(feeEth))
+      expect(transaction.to).toBe(ETH_RECIPIENT)
+      expect(transaction.value).toBe(toSmallestUnit(amount, 1e18))
+      expect(signed.transactionHash).toMatch(/^0x[0-9a-f]{64}$/)
+    }, 120000)
+
+    it('builds 50% ETH balance transactions with Increase fee off and on', async () => {
+      const amount = toFixedAmount(
+        new BigNumber(live.eth.balanceEth).div(2),
+        decimalPlacesFor(Cryptos.ETH)
+      )
+      const txOff = await buildEthTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce
+      })
+      const txOn = await buildEthTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: true,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce
+      })
+
+      expect(BigInt(txOn.transaction.gasPrice)).toBeGreaterThan(BigInt(txOff.transaction.gasPrice))
+      expect(txOff.transaction.value).toBe(toSmallestUnit(amount, 1e18))
+      expect(txOn.transaction.value).toBe(toSmallestUnit(amount, 1e18))
+    }, 120000)
+
+    it('builds a 100% ETH spendable balance transaction with fee reserved', async () => {
+      const feeProbe = await buildEthTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount: getMinAmount(Cryptos.ETH),
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce
+      })
+      const amount = toFixedAmount(
+        new BigNumber(live.eth.balanceEth).minus(feeProbe.feeEth),
+        decimalPlacesFor(Cryptos.ETH)
+      )
+      const transaction = await buildEthTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce
+      })
+
+      expect(new BigNumber(amount).toNumber()).toBeGreaterThanOrEqual(getMinAmount(Cryptos.ETH))
+      expect(transaction.transaction.value).toBe(toSmallestUnit(amount, 1e18))
+    }, 120000)
+
+    it('throws on invalid ETH recipient parameters without broadcasting', async () => {
+      expect(validateAddress(Cryptos.ETH, INVALID_ADDRESS)).toBe(false)
+
+      await expect(
+        buildEthTransfer({
+          client: live.eth.client,
+          account: live.eth.account,
+          recipient: INVALID_ADDRESS,
+          amount: getMinAmount(Cryptos.ETH),
+          increaseFee: false,
+          gasPriceWei: live.eth.gasPriceWei,
+          nonce: live.eth.nonce
+        })
+      ).rejects.toThrow()
+    }, 120000)
+  })
+
+  describe('USDT', () => {
+    it('builds a minTransferAmount USDT transaction from live balances and gas data', async () => {
+      const amount = getMinAmount(Cryptos.USDT)
+      const { transaction, signed, feeEth } = await buildUsdtTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce,
+        contractAddress: live.usdt.contractAddress,
+        decimals: live.usdt.decimals
+      })
+
+      expect(new BigNumber(live.usdt.balance).toNumber()).toBeGreaterThanOrEqual(amount)
+      expect(new BigNumber(live.eth.balanceEth).toNumber()).toBeGreaterThan(Number(feeEth))
+      expect(transaction.to).toBe(live.usdt.contractAddress)
+      expect(transaction.data).toMatch(/^0xa9059cbb/)
+      expect(signed.transactionHash).toMatch(/^0x[0-9a-f]{64}$/)
+    }, 120000)
+
+    it('builds 50% USDT balance transactions with Increase fee off and on', async () => {
+      const amount = toFixedAmount(
+        new BigNumber(live.usdt.balance).div(2),
+        decimalPlacesFor(Cryptos.USDT)
+      )
+      const txOff = await buildUsdtTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce,
+        contractAddress: live.usdt.contractAddress,
+        decimals: live.usdt.decimals
+      })
+      const txOn = await buildUsdtTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount,
+        increaseFee: true,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce,
+        contractAddress: live.usdt.contractAddress,
+        decimals: live.usdt.decimals
+      })
+
+      expect(BigInt(txOn.transaction.gasPrice)).toBeGreaterThan(BigInt(txOff.transaction.gasPrice))
+      expect(txOff.transaction.data).toMatch(/^0xa9059cbb/)
+      expect(txOn.transaction.data).toMatch(/^0xa9059cbb/)
+    }, 120000)
+
+    it('builds a 100% USDT balance transaction while keeping ETH fee external', async () => {
+      const transaction = await buildUsdtTransfer({
+        client: live.eth.client,
+        account: live.eth.account,
+        recipient: ETH_RECIPIENT,
+        amount: live.usdt.balance,
+        increaseFee: false,
+        gasPriceWei: live.eth.gasPriceWei,
+        nonce: live.eth.nonce,
+        contractAddress: live.usdt.contractAddress,
+        decimals: live.usdt.decimals
+      })
+
+      expect(new BigNumber(live.eth.balanceEth).toNumber()).toBeGreaterThan(
+        Number(transaction.feeEth)
+      )
+      expect(transaction.transaction.data).toMatch(/^0xa9059cbb/)
+    }, 120000)
+
+    it('throws on invalid USDT recipient parameters without broadcasting', async () => {
+      expect(validateAddress(Cryptos.USDT, INVALID_ADDRESS)).toBe(false)
+
+      await expect(
+        buildUsdtTransfer({
+          client: live.eth.client,
+          account: live.eth.account,
+          recipient: INVALID_ADDRESS,
+          amount: getMinAmount(Cryptos.USDT),
+          increaseFee: false,
+          gasPriceWei: live.eth.gasPriceWei,
+          nonce: live.eth.nonce,
+          contractAddress: live.usdt.contractAddress,
+          decimals: live.usdt.decimals
+        })
+      ).rejects.toThrow()
+    }, 120000)
+  })
+})

--- a/src/lib/nodes/dash/DashClient.spec.ts
+++ b/src/lib/nodes/dash/DashClient.spec.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from 'vitest'
+import { DashClient } from './DashClient'
+import { TransactionNotFound } from '../utils/errors'
+
+describe('DashClient', () => {
+  it('maps missing transactions to TransactionNotFound in getTransaction', async () => {
+    const client = new DashClient([])
+
+    vi.spyOn(client, 'invoke').mockRejectedValueOnce(
+      new Error(
+        'No such mempool or blockchain transaction. Use gettransaction for wallet transactions.'
+      )
+    )
+
+    await expect(client.getTransaction('dash-tx-id', 'XdashAddress')).rejects.toEqual(
+      new TransactionNotFound('dash-tx-id', 'dash')
+    )
+  })
+
+  it('maps missing transactions to TransactionNotFound in getTransactionHex', async () => {
+    const client = new DashClient([])
+
+    vi.spyOn(client, 'invoke').mockRejectedValueOnce(new Error('Transaction not found'))
+
+    await expect(client.getTransactionHex('dash-tx-id')).rejects.toEqual(
+      new TransactionNotFound('dash-tx-id', 'dash')
+    )
+  })
+
+  it('maps RPC 500 not-found payloads to TransactionNotFound', async () => {
+    const client = new DashClient([])
+
+    vi.spyOn(client, 'invoke').mockRejectedValueOnce({
+      response: {
+        status: 500,
+        data: {
+          error: {
+            message:
+              'No such mempool or blockchain transaction. Use gettransaction for wallet transactions.'
+          }
+        }
+      }
+    })
+
+    await expect(client.getTransaction('dash-tx-id', 'XdashAddress')).rejects.toEqual(
+      new TransactionNotFound('dash-tx-id', 'dash')
+    )
+  })
+})

--- a/src/lib/nodes/dash/DashClient.ts
+++ b/src/lib/nodes/dash/DashClient.ts
@@ -8,6 +8,29 @@ import { RpcRequest } from './types/api/common'
 import { UTXO } from './types/api/utxo'
 import { Balance } from './types/api/balance'
 import { Transaction } from './types/api/transaction'
+import { TransactionNotFound } from '../utils/errors'
+
+function isDashTransactionNotFoundError(error: unknown) {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const messageCandidates = [
+    error instanceof Error ? error.message : '',
+    (error as { response?: { data?: { error?: { message?: string }; message?: string } } }).response
+      ?.data?.error?.message,
+    (error as { response?: { data?: { error?: { message?: string }; message?: string } } }).response
+      ?.data?.message
+  ]
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.toLowerCase())
+
+  return messageCandidates.some(
+    (message) =>
+      message.includes('no such mempool or blockchain transaction') ||
+      message.includes('transaction not found')
+  )
+}
 
 export class DashClient extends Client<DashNode> {
   constructor(endpoints: NodeInfo[] = [], minNodeVersion = '0.0.0') {
@@ -39,19 +62,39 @@ export class DashClient extends Client<DashNode> {
   }
 
   async getTransaction(transactionId: string, address: string) {
-    const transaction = await this.invoke<Transaction>({
-      method: 'getrawtransaction',
-      params: [transactionId, true]
-    })
+    let transaction: Transaction
+
+    try {
+      transaction = await this.invoke<Transaction>({
+        method: 'getrawtransaction',
+        params: [transactionId, true]
+      })
+    } catch (error) {
+      if (isDashTransactionNotFoundError(error)) {
+        throw new TransactionNotFound(transactionId, this.type)
+      }
+
+      throw error
+    }
 
     return normalizeTransaction(transaction, address)
   }
 
   async getTransactionHex(transactionId: string) {
-    const transaction = await this.invoke<string>({
-      method: 'getrawtransaction',
-      params: [transactionId, false]
-    })
+    let transaction: string
+
+    try {
+      transaction = await this.invoke<string>({
+        method: 'getrawtransaction',
+        params: [transactionId, false]
+      })
+    } catch (error) {
+      if (isDashTransactionNotFoundError(error)) {
+        throw new TransactionNotFound(transactionId, this.type)
+      }
+
+      throw error
+    }
 
     return transaction
   }

--- a/src/lib/nodes/dash/DashClient.ts
+++ b/src/lib/nodes/dash/DashClient.ts
@@ -56,12 +56,15 @@ export class DashClient extends Client<DashNode> {
     return transaction
   }
 
-  async getTransactionsIds() {
-    return this.invoke<string[]>({ method: 'getaddresstxids' })
+  async getTransactionsIds(address: string) {
+    return this.invoke<string[]>({
+      method: 'getaddresstxids',
+      params: [address]
+    })
   }
 
   async getTransactions(address: string) {
-    const txIds = await this.getTransactionsIds()
+    const txIds = await this.getTransactionsIds(address)
 
     const rpcCalls = txIds.map((txId) => ({
       method: 'getrawtransaction',

--- a/src/lib/nodes/dash/utils.spec.ts
+++ b/src/lib/nodes/dash/utils.spec.ts
@@ -180,4 +180,27 @@ describe('normalizeTransaction', () => {
     // Assert: amount should be first output (1000)
     expect(result.amount).toBe(1000)
   })
+
+  it('should calculate fee without floating-point drift', () => {
+    const result = normalizeTransaction(
+      {
+        ...txSelfTransfer,
+        vin: [
+          {
+            ...txSelfTransfer.vin[0],
+            value: 0.0014
+          }
+        ],
+        vout: [
+          {
+            ...txSelfTransfer.vout[0],
+            value: 0.0013
+          }
+        ]
+      },
+      OWNER_ADDRESS
+    )
+
+    expect(result.fee).toBe(0.0001)
+  })
 })

--- a/src/lib/nodes/dash/utils.spec.ts
+++ b/src/lib/nodes/dash/utils.spec.ts
@@ -203,4 +203,21 @@ describe('normalizeTransaction', () => {
 
     expect(result.fee).toBe(0.0001)
   })
+
+  it('should preserve Dash InstantSend flags in the normalized transaction', () => {
+    const result = normalizeTransaction(
+      {
+        ...txWithDuplicateSenders,
+        confirmations: 0,
+        instantlock: true,
+        instantlock_internal: true
+      },
+      OWNER_ADDRESS
+    )
+
+    expect(result.status).toBe('REGISTERED')
+    expect(result.instantlock).toBe(true)
+    expect(result.instantlock_internal).toBe(true)
+    expect(result.instantsend).toBe(true)
+  })
 })

--- a/src/lib/nodes/dash/utils.ts
+++ b/src/lib/nodes/dash/utils.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js'
 import { DashTransaction } from '@/lib/nodes/types/transaction'
 import { Transaction } from './types/api/transaction'
 
@@ -46,9 +47,9 @@ export function normalizeTransaction(tx: Transaction, ownerAddress: string): Das
   const confirmations = tx.confirmations
   const timestamp = tx.time * 1000
 
-  const totalIn = tx.vin.reduce((sum, x) => sum + (x.value ? +x.value : 0), 0)
-  const totalOut = tx.vout.reduce((sum, x) => sum + (x.value ? +x.value : 0), 0)
-  const fee = totalIn - totalOut
+  const totalIn = tx.vin.reduce((sum, x) => sum.plus(x.value ? x.value : 0), new BigNumber(0))
+  const totalOut = tx.vout.reduce((sum, x) => sum.plus(x.value ? x.value : 0), new BigNumber(0))
+  const fee = totalIn.minus(totalOut).toNumber()
 
   const height = tx.height
 

--- a/src/lib/nodes/dash/utils.ts
+++ b/src/lib/nodes/dash/utils.ts
@@ -67,6 +67,9 @@ export function normalizeTransaction(tx: Transaction, ownerAddress: string): Das
     recipientId,
     amount,
     confirmations,
-    height
+    height,
+    instantlock: tx.instantlock,
+    instantlock_internal: tx.instantlock_internal,
+    instantsend: tx.instantlock
   }
 }

--- a/src/lib/nodes/doge-indexer/DogeIndexerClient.ts
+++ b/src/lib/nodes/doge-indexer/DogeIndexerClient.ts
@@ -6,7 +6,11 @@ import { Client } from '../abstract.client'
 import { NB_BLOCKS } from './constants'
 import { normalizeTransaction } from './utils'
 import { NodeStatus } from './types/api/node-status'
-import { Transaction, GetTransactionsParams } from './types/api/transaction'
+import {
+  Transaction,
+  GetTransactionsParams,
+  GetTransactionsResponse
+} from './types/api/transaction'
 import { GetUnspentsParams, UTXO } from './types/api/utxo'
 import { AddressInfo } from './types/api/address'
 import { EstimatedFee, GetEstimatedFeeParams } from './types/api/estimated-fee'
@@ -42,11 +46,14 @@ export class DogeIndexerClient extends Client<DogeIndexer> {
   }
 
   async getTransactions(address: string, params: GetTransactionsParams = {}) {
-    const transactions = await this.request<Transaction[], GetTransactionsParams>(
+    const response = await this.request<GetTransactionsResponse, GetTransactionsParams>(
       'GET',
       `/api/addrs/${address}/txs`,
       params
     )
+    const transactions = Array.isArray(response)
+      ? response
+      : response.items || response.txs || response.transactions || []
 
     return transactions.map((transaction) => normalizeTransaction(transaction, address))
   }

--- a/src/lib/nodes/doge-indexer/types/api/transaction.ts
+++ b/src/lib/nodes/doge-indexer/types/api/transaction.ts
@@ -54,3 +54,11 @@ export type GetTransactionsParams = {
   from?: number
   to?: number
 }
+
+export type GetTransactionsResponse =
+  | Transaction[]
+  | {
+      items?: Transaction[]
+      txs?: Transaction[]
+      transactions?: Transaction[]
+    }

--- a/src/lib/nodes/types/transaction.ts
+++ b/src/lib/nodes/types/transaction.ts
@@ -65,6 +65,10 @@ export type BtcTransaction = Omit<CoinTransaction, 'confirmations'> & {
 }
 
 export type DogeTransaction = Omit<BtcTransaction, 'height'>
-export type DashTransaction = BtcTransaction
+export type DashTransaction = BtcTransaction & {
+  instantlock?: boolean
+  instantlock_internal?: boolean
+  instantsend?: boolean
+}
 
 export type AnyCoinTransaction = BtcTransaction | DogeTransaction | DashTransaction | EthTransaction

--- a/src/lib/transaction-status-icons.spec.ts
+++ b/src/lib/transaction-status-icons.spec.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest'
+import { TransactionStatus, tsIcon } from '@/lib/constants'
+
+describe('transaction status icons', () => {
+  it('renders REGISTERED with a different icon than CONFIRMED', () => {
+    expect(tsIcon(TransactionStatus.REGISTERED)).not.toBe(tsIcon(TransactionStatus.CONFIRMED))
+  })
+
+  it('keeps pending and registered visually distinct', () => {
+    expect(tsIcon(TransactionStatus.REGISTERED)).not.toBe(tsIcon(TransactionStatus.PENDING))
+  })
+})

--- a/src/providers/TransactionProvider/TransactionProvider.vue
+++ b/src/providers/TransactionProvider/TransactionProvider.vue
@@ -18,7 +18,7 @@
 <script lang="ts">
 import { computed, defineComponent, PropType } from 'vue'
 import TransactionStatusProvider from './TransactionStatusProvider.vue'
-import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 import { TransactionStatus } from '@/lib/constants'
 
 export default defineComponent({

--- a/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
@@ -4,6 +4,12 @@ import { createStore } from 'vuex'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TransactionStatus } from '@/lib/constants'
 import TransactionStatusProvider from './TransactionStatusProvider.vue'
+import {
+  makeTransactionStatusSessionKey,
+  rememberTransactionFinalStatus,
+  resetTransactionStatusSessionCache,
+  syncTransactionStatusSession
+} from './sessionFinalStatusCache'
 
 const {
   queryStatusRef,
@@ -70,8 +76,13 @@ const createStoreMock = () => {
     state: {
       address: 'U111111'
     },
-    mutations: {
-      noop() {}
+    modules: {
+      chat: {
+        namespaced: true,
+        mutations: {
+          updateCryptoTransferMessage() {}
+        }
+      }
     }
   })
 
@@ -82,6 +93,7 @@ const createStoreMock = () => {
 
 describe('TransactionStatusProvider', () => {
   beforeEach(() => {
+    resetTransactionStatusSessionCache()
     queryStatusRef.value = 'pending'
     liveStatusRef.value = TransactionStatus.PENDING
     transactionRef.value = undefined
@@ -154,6 +166,78 @@ describe('TransactionStatusProvider', () => {
     expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
       TransactionStatus.CONFIRMED
     )
+  })
+
+  it('skips auto-query on the next chat remount in the same session once an invalid status was remembered', () => {
+    const { store } = createStoreMock()
+    syncTransactionStatusSession('U111111')
+    rememberTransactionFinalStatus(
+      makeTransactionStatusSessionKey('U111111', 'BTC', 'btc-hash'),
+      TransactionStatus.INVALID
+    )
+
+    queryStatusRef.value = 'pending'
+    liveStatusRef.value = TransactionStatus.PENDING
+    transactionRef.value = undefined
+    inconsistentStatusRef.value = ''
+
+    const wrapper = mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'btc-hash',
+          type: 'BTC',
+          senderId: 'U111111',
+          recipientId: 'U222222',
+          status: TransactionStatus.INVALID
+        }
+      },
+      global: {
+        plugins: [store]
+      }
+    })
+
+    const params = useTransactionStatusQueryMock.mock.calls[0]?.[2] as
+      | { enabled: { value: boolean } }
+      | undefined
+
+    expect(params?.enabled.value).toBe(false)
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.INVALID)
+  })
+
+  it('skips auto-query on the next chat remount in the same session once a rejected status was remembered', () => {
+    const { store } = createStoreMock()
+    syncTransactionStatusSession('U111111')
+    rememberTransactionFinalStatus(
+      makeTransactionStatusSessionKey('U111111', 'DOGE', 'doge-hash'),
+      TransactionStatus.REJECTED
+    )
+
+    queryStatusRef.value = 'pending'
+    liveStatusRef.value = TransactionStatus.PENDING
+
+    const wrapper = mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'doge-hash',
+          type: 'DOGE',
+          senderId: 'U111111',
+          recipientId: 'U222222',
+          status: TransactionStatus.REJECTED
+        }
+      },
+      global: {
+        plugins: [store]
+      }
+    })
+
+    const params = useTransactionStatusQueryMock.mock.calls[0]?.[2] as
+      | { enabled: { value: boolean } }
+      | undefined
+
+    expect(params?.enabled.value).toBe(false)
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.REJECTED)
   })
 
   it('keeps live queries enabled for crypto transfers that are locally marked as rejected', () => {

--- a/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
@@ -110,7 +110,7 @@ describe('TransactionStatusProvider', () => {
     expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.PENDING)
   })
 
-  it('keeps the local registered status when the live query errors before the transaction is indexed', () => {
+  it('uses the live rejected status when the query layer resolves the transfer as failed', () => {
     queryStatusRef.value = 'error'
     liveStatusRef.value = TransactionStatus.REJECTED
     const { store } = createStoreMock()
@@ -129,9 +129,7 @@ describe('TransactionStatusProvider', () => {
       }
     })
 
-    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
-      TransactionStatus.REGISTERED
-    )
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.REJECTED)
   })
 
   it('uses the live success status once it is available', () => {
@@ -179,6 +177,30 @@ describe('TransactionStatusProvider', () => {
       | undefined
 
     expect(params?.knownStatus.value).toBe(TransactionStatus.REJECTED)
+    expect(params?.enabled.value).toBe(true)
+  })
+
+  it('keeps live queries enabled for crypto transfers that are locally marked as confirmed', () => {
+    const { store } = createStoreMock()
+    mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'btc-hash',
+          type: 'BTC',
+          status: TransactionStatus.CONFIRMED
+        }
+      },
+      global: {
+        plugins: [store]
+      }
+    })
+
+    const params = useTransactionStatusQueryMock.mock.calls[0]?.[2] as
+      | { knownStatus: { value: string }; enabled: { value: boolean } }
+      | undefined
+
+    expect(params?.knownStatus.value).toBe(TransactionStatus.CONFIRMED)
     expect(params?.enabled.value).toBe(true)
   })
 })

--- a/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
@@ -1,0 +1,142 @@
+import { defineComponent, h, PropType } from 'vue'
+import { mount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { TransactionStatus } from '@/lib/constants'
+import TransactionStatusProvider from './TransactionStatusProvider.vue'
+
+const {
+  queryStatusRef,
+  liveStatusRef,
+  inconsistentStatusRef,
+  refetch,
+  useTransactionStatusQueryMock
+} = vi.hoisted(() => {
+  const queryStatusRef = { value: 'pending' as 'pending' | 'error' | 'success' }
+  const liveStatusRef = { value: 'PENDING' }
+  const inconsistentStatusRef = { value: '' }
+  const refetch = vi.fn()
+  const useTransactionStatusQueryMock = vi.fn(
+    (_transactionId?: unknown, _crypto?: unknown, _params?: unknown) => ({
+      queryStatus: queryStatusRef,
+      status: liveStatusRef,
+      inconsistentStatus: inconsistentStatusRef,
+      refetch
+    })
+  )
+
+  return {
+    queryStatusRef,
+    liveStatusRef,
+    inconsistentStatusRef,
+    refetch,
+    useTransactionStatusQueryMock
+  }
+})
+
+vi.mock('@/hooks/queries/transaction', () => ({
+  useTransactionStatusQuery: useTransactionStatusQueryMock
+}))
+
+const slotHost = defineComponent({
+  props: {
+    transaction: {
+      type: Object as PropType<Record<string, any>>,
+      required: true
+    }
+  },
+  setup(props) {
+    return () =>
+      h(
+        TransactionStatusProvider as any,
+        { transaction: props.transaction },
+        {
+          default: ({ status }: { status: string }) => h('div', { 'data-status': status }, status)
+        }
+      )
+  }
+})
+
+describe('TransactionStatusProvider', () => {
+  beforeEach(() => {
+    queryStatusRef.value = 'pending'
+    liveStatusRef.value = TransactionStatus.PENDING
+    inconsistentStatusRef.value = ''
+    refetch.mockReset()
+    useTransactionStatusQueryMock.mockClear()
+  })
+
+  it('keeps the local pending status in chat preview while the live query is still pending', () => {
+    const wrapper = mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'dash-hash',
+          type: 'DASH',
+          status: TransactionStatus.PENDING
+        }
+      }
+    })
+
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.PENDING)
+  })
+
+  it('keeps the local registered status when the live query errors before the transaction is indexed', () => {
+    queryStatusRef.value = 'error'
+    liveStatusRef.value = TransactionStatus.REJECTED
+
+    const wrapper = mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'doge-hash',
+          type: 'DOGE',
+          status: TransactionStatus.REGISTERED
+        }
+      }
+    })
+
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
+      TransactionStatus.REGISTERED
+    )
+  })
+
+  it('uses the live success status once it is available', () => {
+    queryStatusRef.value = 'success'
+    liveStatusRef.value = TransactionStatus.CONFIRMED
+
+    const wrapper = mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'dash-hash',
+          type: 'DASH',
+          status: TransactionStatus.PENDING
+        }
+      }
+    })
+
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(
+      TransactionStatus.CONFIRMED
+    )
+  })
+
+  it('keeps live queries enabled for crypto transfers that are locally marked as rejected', () => {
+    mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'btc-hash',
+          type: 'BTC',
+          status: TransactionStatus.REJECTED
+        }
+      }
+    })
+
+    const params = useTransactionStatusQueryMock.mock.calls[0]?.[2] as
+      | { knownStatus: { value: string }; enabled: { value: boolean } }
+      | undefined
+
+    expect(params?.knownStatus.value).toBe(TransactionStatus.REJECTED)
+    expect(params?.enabled.value).toBe(true)
+  })
+})

--- a/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
@@ -172,7 +172,7 @@ describe('TransactionStatusProvider', () => {
     )
   })
 
-  it('skips auto-query on the next chat remount in the same session once an invalid status was remembered', () => {
+  it('keeps auto-query enabled for invalid statuses so stale inconsistency results can self-heal', () => {
     const { store } = createStoreMock()
     syncTransactionStatusSession('U111111')
     rememberTransactionFinalStatus(
@@ -205,8 +205,8 @@ describe('TransactionStatusProvider', () => {
       | { enabled: { value: boolean } }
       | undefined
 
-    expect(params?.enabled.value).toBe(false)
-    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.INVALID)
+    expect(params?.enabled.value).toBe(true)
+    expect(wrapper.find('[data-status]').attributes('data-status')).toBe(TransactionStatus.PENDING)
   })
 
   it('skips auto-query on the next chat remount in the same session once a rejected status was remembered', () => {

--- a/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
@@ -65,7 +65,11 @@ const slotHost = defineComponent({
         TransactionStatusProvider as any,
         { transaction: props.transaction },
         {
-          default: ({ status }: { status: string }) => h('div', { 'data-status': status }, status)
+          default: ({ status, refetch }: { status: string; refetch: () => void }) =>
+            h('div', [
+              h('div', { 'data-status': status }, status),
+              h('button', { 'data-refetch': '', onClick: refetch }, 'refetch')
+            ])
         }
       )
   }
@@ -286,5 +290,39 @@ describe('TransactionStatusProvider', () => {
 
     expect(params?.knownStatus.value).toBe(TransactionStatus.CONFIRMED)
     expect(params?.enabled.value).toBe(true)
+  })
+
+  it('clears the remembered final status and sets chat transfer back to pending on manual refetch', async () => {
+    const { store, commit } = createStoreMock()
+    syncTransactionStatusSession('U111111')
+    rememberTransactionFinalStatus(
+      makeTransactionStatusSessionKey('U111111', 'DASH', 'dash-hash'),
+      TransactionStatus.REJECTED
+    )
+
+    const wrapper = mount(slotHost, {
+      props: {
+        transaction: {
+          id: 'local-id',
+          hash: 'dash-hash',
+          type: 'DASH',
+          senderId: 'U111111',
+          recipientId: 'U222222',
+          status: TransactionStatus.REJECTED
+        }
+      },
+      global: {
+        plugins: [store]
+      }
+    })
+
+    await wrapper.find('[data-refetch]').trigger('click')
+
+    expect(commit).toHaveBeenCalledWith('chat/updateCryptoTransferMessage', {
+      partnerId: 'U222222',
+      hash: 'dash-hash',
+      status: TransactionStatus.PENDING
+    })
+    expect(refetch).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.spec.ts
@@ -1,5 +1,6 @@
 import { defineComponent, h, PropType } from 'vue'
 import { mount } from '@vue/test-utils'
+import { createStore } from 'vuex'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { TransactionStatus } from '@/lib/constants'
 import TransactionStatusProvider from './TransactionStatusProvider.vue'
@@ -7,18 +8,24 @@ import TransactionStatusProvider from './TransactionStatusProvider.vue'
 const {
   queryStatusRef,
   liveStatusRef,
+  transactionRef,
+  additionalStatusRef,
   inconsistentStatusRef,
   refetch,
   useTransactionStatusQueryMock
 } = vi.hoisted(() => {
   const queryStatusRef = { value: 'pending' as 'pending' | 'error' | 'success' }
   const liveStatusRef = { value: 'PENDING' }
+  const transactionRef = { value: undefined as Record<string, any> | undefined }
+  const additionalStatusRef = { value: false as string | boolean }
   const inconsistentStatusRef = { value: '' }
   const refetch = vi.fn()
   const useTransactionStatusQueryMock = vi.fn(
     (_transactionId?: unknown, _crypto?: unknown, _params?: unknown) => ({
+      transaction: transactionRef,
       queryStatus: queryStatusRef,
       status: liveStatusRef,
+      additionalStatus: additionalStatusRef,
       inconsistentStatus: inconsistentStatusRef,
       refetch
     })
@@ -27,6 +34,8 @@ const {
   return {
     queryStatusRef,
     liveStatusRef,
+    transactionRef,
+    additionalStatusRef,
     inconsistentStatusRef,
     refetch,
     useTransactionStatusQueryMock
@@ -56,16 +65,34 @@ const slotHost = defineComponent({
   }
 })
 
+const createStoreMock = () => {
+  const store = createStore({
+    state: {
+      address: 'U111111'
+    },
+    mutations: {
+      noop() {}
+    }
+  })
+
+  const commit = vi.spyOn(store, 'commit')
+
+  return { store, commit }
+}
+
 describe('TransactionStatusProvider', () => {
   beforeEach(() => {
     queryStatusRef.value = 'pending'
     liveStatusRef.value = TransactionStatus.PENDING
+    transactionRef.value = undefined
+    additionalStatusRef.value = false
     inconsistentStatusRef.value = ''
     refetch.mockReset()
     useTransactionStatusQueryMock.mockClear()
   })
 
   it('keeps the local pending status in chat preview while the live query is still pending', () => {
+    const { store } = createStoreMock()
     const wrapper = mount(slotHost, {
       props: {
         transaction: {
@@ -74,6 +101,9 @@ describe('TransactionStatusProvider', () => {
           type: 'DASH',
           status: TransactionStatus.PENDING
         }
+      },
+      global: {
+        plugins: [store]
       }
     })
 
@@ -83,6 +113,7 @@ describe('TransactionStatusProvider', () => {
   it('keeps the local registered status when the live query errors before the transaction is indexed', () => {
     queryStatusRef.value = 'error'
     liveStatusRef.value = TransactionStatus.REJECTED
+    const { store } = createStoreMock()
 
     const wrapper = mount(slotHost, {
       props: {
@@ -92,6 +123,9 @@ describe('TransactionStatusProvider', () => {
           type: 'DOGE',
           status: TransactionStatus.REGISTERED
         }
+      },
+      global: {
+        plugins: [store]
       }
     })
 
@@ -103,6 +137,7 @@ describe('TransactionStatusProvider', () => {
   it('uses the live success status once it is available', () => {
     queryStatusRef.value = 'success'
     liveStatusRef.value = TransactionStatus.CONFIRMED
+    const { store } = createStoreMock()
 
     const wrapper = mount(slotHost, {
       props: {
@@ -112,6 +147,9 @@ describe('TransactionStatusProvider', () => {
           type: 'DASH',
           status: TransactionStatus.PENDING
         }
+      },
+      global: {
+        plugins: [store]
       }
     })
 
@@ -121,6 +159,7 @@ describe('TransactionStatusProvider', () => {
   })
 
   it('keeps live queries enabled for crypto transfers that are locally marked as rejected', () => {
+    const { store } = createStoreMock()
     mount(slotHost, {
       props: {
         transaction: {
@@ -129,6 +168,9 @@ describe('TransactionStatusProvider', () => {
           type: 'BTC',
           status: TransactionStatus.REJECTED
         }
+      },
+      global: {
+        plugins: [store]
       }
     })
 

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -29,21 +29,22 @@ export default defineComponent({
     )
     const crypto = computed(() => props.transaction.type)
 
-    const isNotFinalized = computed(() => {
-      const { status } = props.transaction
-      return status === TransactionStatus.REGISTERED || status === TransactionStatus.PENDING
-    })
     const isSupportedCrypto = computed(() => {
       return props.transaction.type in Cryptos
     })
+    const queryKnownStatus = computed(() => props.transaction.status)
     const queryEnabled = computed(() => {
-      return isNotFinalized.value && isSupportedCrypto.value
+      return (
+        isSupportedCrypto.value &&
+        !!transactionId.value &&
+        props.transaction.status !== TransactionStatus.CONFIRMED
+      )
     })
 
     const { queryStatus, status, inconsistentStatus, refetch } = useTransactionStatusQuery(
       transactionId,
       crypto.value as CryptoSymbol,
-      { enabled: queryEnabled }
+      { enabled: queryEnabled, knownStatus: queryKnownStatus }
     )
 
     const transactionStatus = computed(() => {
@@ -51,13 +52,18 @@ export default defineComponent({
         return TransactionStatus.UNKNOWN
       }
 
-      if (props.transaction.type === 'ADM') {
-        return props.transaction.status === TransactionStatus.CONFIRMED
-          ? TransactionStatus.CONFIRMED
-          : status.value
+      if (!queryEnabled.value || queryStatus.value === 'pending') {
+        return props.transaction.status
       }
 
-      // other cryptos
+      if (
+        queryStatus.value === 'error' &&
+        props.transaction.status !== TransactionStatus.REJECTED &&
+        props.transaction.status !== TransactionStatus.UNKNOWN
+      ) {
+        return props.transaction.status
+      }
+
       return status.value
     })
 

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -8,10 +8,19 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, PropType } from 'vue'
+import { computed, defineComponent, PropType, watch } from 'vue'
+import { useStore } from 'vuex'
 import { useTransactionStatusQuery } from '@/hooks/queries/transaction'
-import { Cryptos, CryptoSymbol, TransactionStatus, tsIcon } from '@/lib/constants'
+import {
+  Cryptos,
+  CryptoSymbol,
+  TransactionAdditionalStatus,
+  TransactionStatus,
+  tsIcon
+} from '@/lib/constants'
 import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
+import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
+import { isStringEqualCI } from '@/lib/textHelpers'
 
 export default defineComponent({
   props: {
@@ -24,10 +33,25 @@ export default defineComponent({
     }
   },
   setup(props) {
+    const store = useStore()
     const transactionId = computed(() =>
       props.transaction.type === 'ADM' ? props.transaction.id : props.transaction.hash
     )
-    const crypto = computed(() => props.transaction.type)
+    const crypto = computed(() => props.transaction.type as CryptoSymbol)
+    const localAdditionalStatus = useTransactionAdditionalStatus(
+      computed(() => props.transaction as any),
+      crypto
+    )
+    const localResolvedStatus = computed(() =>
+      localAdditionalStatus.value === TransactionAdditionalStatus.INSTANT_SEND
+        ? TransactionStatus.CONFIRMED
+        : props.transaction.status
+    )
+    const partnerId = computed(() =>
+      isStringEqualCI(props.transaction.senderId, store.state.address)
+        ? props.transaction.recipientId
+        : props.transaction.senderId
+    )
 
     const isSupportedCrypto = computed(() => {
       return props.transaction.type in Cryptos
@@ -41,10 +65,47 @@ export default defineComponent({
       )
     })
 
-    const { queryStatus, status, inconsistentStatus, refetch } = useTransactionStatusQuery(
-      transactionId,
-      crypto.value as CryptoSymbol,
-      { enabled: queryEnabled, knownStatus: queryKnownStatus }
+    const { transaction, queryStatus, status, inconsistentStatus, additionalStatus, refetch } =
+      useTransactionStatusQuery(transactionId, crypto, {
+        enabled: queryEnabled,
+        knownStatus: queryKnownStatus
+      })
+
+    watch(
+      transaction,
+      (liveTransaction) => {
+        const resolvedLiveTransaction = liveTransaction as any
+
+        if (
+          queryStatus.value !== 'success' ||
+          !resolvedLiveTransaction ||
+          !partnerId.value ||
+          !props.transaction.hash
+        ) {
+          return
+        }
+
+        store.commit('chat/updateCryptoTransferMessage', {
+          partnerId: partnerId.value,
+          hash: props.transaction.hash,
+          status: resolvedLiveTransaction.status,
+          confirmations: resolvedLiveTransaction.confirmations,
+          instantlock:
+            'instantlock' in resolvedLiveTransaction
+              ? resolvedLiveTransaction.instantlock
+              : undefined,
+          instantlock_internal:
+            'instantlock_internal' in resolvedLiveTransaction
+              ? resolvedLiveTransaction.instantlock_internal
+              : undefined,
+          instantsend:
+            additionalStatus.value === TransactionAdditionalStatus.INSTANT_SEND ||
+            ('instantsend' in resolvedLiveTransaction
+              ? resolvedLiveTransaction.instantsend
+              : undefined)
+        })
+      },
+      { immediate: true }
     )
 
     const transactionStatus = computed(() => {
@@ -53,7 +114,7 @@ export default defineComponent({
       }
 
       if (!queryEnabled.value || queryStatus.value === 'pending') {
-        return props.transaction.status
+        return localResolvedStatus.value
       }
 
       if (
@@ -61,7 +122,7 @@ export default defineComponent({
         props.transaction.status !== TransactionStatus.REJECTED &&
         props.transaction.status !== TransactionStatus.UNKNOWN
       ) {
-        return props.transaction.status
+        return localResolvedStatus.value
       }
 
       return status.value

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -18,7 +18,7 @@ import {
   TransactionStatus,
   tsIcon
 } from '@/lib/constants'
-import { NormalizedChatMessageTransaction } from '@/lib/chat/helpers'
+import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
 import { isStringEqualCI } from '@/lib/textHelpers'
 
@@ -58,11 +58,7 @@ export default defineComponent({
     })
     const queryKnownStatus = computed(() => props.transaction.status)
     const queryEnabled = computed(() => {
-      return (
-        isSupportedCrypto.value &&
-        !!transactionId.value &&
-        props.transaction.status !== TransactionStatus.CONFIRMED
-      )
+      return isSupportedCrypto.value && !!transactionId.value
     })
 
     const { transaction, queryStatus, status, inconsistentStatus, additionalStatus, refetch } =
@@ -114,14 +110,6 @@ export default defineComponent({
       }
 
       if (!queryEnabled.value || queryStatus.value === 'pending') {
-        return localResolvedStatus.value
-      }
-
-      if (
-        queryStatus.value === 'error' &&
-        props.transaction.status !== TransactionStatus.REJECTED &&
-        props.transaction.status !== TransactionStatus.UNKNOWN
-      ) {
         return localResolvedStatus.value
       }
 

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -21,6 +21,12 @@ import {
 import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normalizeMessage'
 import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
 import { isStringEqualCI } from '@/lib/textHelpers'
+import {
+  hasTransactionFinalStatusInSession,
+  makeTransactionStatusSessionKey,
+  rememberTransactionFinalStatus,
+  syncTransactionStatusSession
+} from './sessionFinalStatusCache'
 
 export default defineComponent({
   props: {
@@ -34,6 +40,8 @@ export default defineComponent({
   },
   setup(props) {
     const store = useStore()
+    syncTransactionStatusSession(store.state.address)
+
     const transactionId = computed(() =>
       props.transaction.type === 'ADM' ? props.transaction.id : props.transaction.hash
     )
@@ -57,8 +65,14 @@ export default defineComponent({
       return props.transaction.type in Cryptos
     })
     const queryKnownStatus = computed(() => props.transaction.status)
+    const sessionTransactionKey = computed(() =>
+      makeTransactionStatusSessionKey(store.state.address, crypto.value, transactionId.value)
+    )
+    const skipAutoQuery = computed(() =>
+      hasTransactionFinalStatusInSession(sessionTransactionKey.value, localResolvedStatus.value)
+    )
     const queryEnabled = computed(() => {
-      return isSupportedCrypto.value && !!transactionId.value
+      return isSupportedCrypto.value && !!transactionId.value && !skipAutoQuery.value
     })
 
     const { transaction, queryStatus, status, inconsistentStatus, additionalStatus, refetch } =
@@ -81,10 +95,12 @@ export default defineComponent({
           return
         }
 
+        rememberTransactionFinalStatus(sessionTransactionKey.value, status.value)
+
         store.commit('chat/updateCryptoTransferMessage', {
           partnerId: partnerId.value,
           hash: props.transaction.hash,
-          status: resolvedLiveTransaction.status,
+          status: status.value,
           confirmations: resolvedLiveTransaction.confirmations,
           instantlock:
             'instantlock' in resolvedLiveTransaction
@@ -99,6 +115,28 @@ export default defineComponent({
             ('instantsend' in resolvedLiveTransaction
               ? resolvedLiveTransaction.instantsend
               : undefined)
+        })
+      },
+      { immediate: true }
+    )
+
+    watch(
+      status,
+      (resolvedStatus) => {
+        if (!partnerId.value || !props.transaction.hash) {
+          return
+        }
+
+        rememberTransactionFinalStatus(sessionTransactionKey.value, resolvedStatus)
+
+        if (resolvedStatus !== TransactionStatus.REJECTED) {
+          return
+        }
+
+        store.commit('chat/updateCryptoTransferMessage', {
+          partnerId: partnerId.value,
+          hash: props.transaction.hash,
+          status: resolvedStatus
         })
       },
       { immediate: true }

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -22,6 +22,7 @@ import type { NormalizedChatMessageTransaction } from '@/lib/chat/helpers/normal
 import { useTransactionAdditionalStatus } from '@/components/transactions/hooks/useTransactionAdditionalStatus'
 import { isStringEqualCI } from '@/lib/textHelpers'
 import {
+  forgetTransactionFinalStatus,
   hasTransactionFinalStatusInSession,
   makeTransactionStatusSessionKey,
   rememberTransactionFinalStatus,
@@ -142,6 +143,20 @@ export default defineComponent({
       { immediate: true }
     )
 
+    const refetchTransactionStatus = async () => {
+      forgetTransactionFinalStatus(sessionTransactionKey.value)
+
+      if (partnerId.value && props.transaction.hash) {
+        store.commit('chat/updateCryptoTransferMessage', {
+          partnerId: partnerId.value,
+          hash: props.transaction.hash,
+          status: TransactionStatus.PENDING
+        })
+      }
+
+      return refetch()
+    }
+
     const transactionStatus = computed(() => {
       if (props.transaction.type === 'UNKNOWN_CRYPTO') {
         return TransactionStatus.UNKNOWN
@@ -161,7 +176,7 @@ export default defineComponent({
       status: transactionStatus,
       inconsistentStatus,
       statusIcon,
-      refetch
+      refetch: refetchTransactionStatus
     }
   }
 })

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -79,7 +79,8 @@ export default defineComponent({
     const { transaction, queryStatus, status, inconsistentStatus, additionalStatus, refetch } =
       useTransactionStatusQuery(transactionId, crypto, {
         enabled: queryEnabled,
-        knownStatus: queryKnownStatus
+        knownStatus: queryKnownStatus,
+        knownAdmTransaction: computed(() => props.transaction)
       })
 
     watch(

--- a/src/providers/TransactionProvider/TransactionStatusProvider.vue
+++ b/src/providers/TransactionProvider/TransactionStatusProvider.vue
@@ -131,7 +131,11 @@ export default defineComponent({
 
         rememberTransactionFinalStatus(sessionTransactionKey.value, resolvedStatus)
 
-        if (resolvedStatus !== TransactionStatus.REJECTED) {
+        if (
+          resolvedStatus !== TransactionStatus.CONFIRMED &&
+          resolvedStatus !== TransactionStatus.REJECTED &&
+          resolvedStatus !== TransactionStatus.INVALID
+        ) {
           return
         }
 
@@ -161,6 +165,14 @@ export default defineComponent({
     const transactionStatus = computed(() => {
       if (props.transaction.type === 'UNKNOWN_CRYPTO') {
         return TransactionStatus.UNKNOWN
+      }
+
+      if (
+        queryEnabled.value &&
+        queryStatus.value === 'pending' &&
+        localResolvedStatus.value === TransactionStatus.INVALID
+      ) {
+        return TransactionStatus.PENDING
       }
 
       if (!queryEnabled.value || queryStatus.value === 'pending') {

--- a/src/providers/TransactionProvider/sessionFinalStatusCache.ts
+++ b/src/providers/TransactionProvider/sessionFinalStatusCache.ts
@@ -1,0 +1,55 @@
+import { CryptoSymbol, TransactionStatus, TransactionStatusType } from '@/lib/constants'
+
+const finalStatuses = new Set<TransactionStatusType>([
+  TransactionStatus.CONFIRMED,
+  TransactionStatus.REJECTED,
+  TransactionStatus.INVALID
+])
+
+const checkedTransactions = new Set<string>()
+let sessionAddress = ''
+
+function normalizeAddress(address?: string) {
+  return address?.trim() || ''
+}
+
+export function syncTransactionStatusSession(address?: string) {
+  const normalizedAddress = normalizeAddress(address)
+
+  if (!normalizedAddress || sessionAddress !== normalizedAddress) {
+    checkedTransactions.clear()
+  }
+
+  sessionAddress = normalizedAddress
+}
+
+export function makeTransactionStatusSessionKey(
+  address: string | undefined,
+  crypto: CryptoSymbol,
+  transactionId: string | undefined
+) {
+  const normalizedAddress = normalizeAddress(address)
+
+  if (!normalizedAddress || !transactionId) {
+    return ''
+  }
+
+  return `${normalizedAddress}:${crypto}:${transactionId}`
+}
+
+export function rememberTransactionFinalStatus(key: string, status?: TransactionStatusType) {
+  if (!key || !status || !finalStatuses.has(status)) {
+    return
+  }
+
+  checkedTransactions.add(key)
+}
+
+export function hasTransactionFinalStatusInSession(key: string, status?: TransactionStatusType) {
+  return !!key && !!status && finalStatuses.has(status) && checkedTransactions.has(key)
+}
+
+export function resetTransactionStatusSessionCache() {
+  checkedTransactions.clear()
+  sessionAddress = ''
+}

--- a/src/providers/TransactionProvider/sessionFinalStatusCache.ts
+++ b/src/providers/TransactionProvider/sessionFinalStatusCache.ts
@@ -45,6 +45,14 @@ export function rememberTransactionFinalStatus(key: string, status?: Transaction
   checkedTransactions.add(key)
 }
 
+export function forgetTransactionFinalStatus(key: string) {
+  if (!key) {
+    return
+  }
+
+  checkedTransactions.delete(key)
+}
+
 export function hasTransactionFinalStatusInSession(key: string, status?: TransactionStatusType) {
   return !!key && !!status && finalStatuses.has(status) && checkedTransactions.has(key)
 }

--- a/src/providers/TransactionProvider/sessionFinalStatusCache.ts
+++ b/src/providers/TransactionProvider/sessionFinalStatusCache.ts
@@ -2,8 +2,7 @@ import { CryptoSymbol, TransactionStatus, TransactionStatusType } from '@/lib/co
 
 const finalStatuses = new Set<TransactionStatusType>([
   TransactionStatus.CONFIRMED,
-  TransactionStatus.REJECTED,
-  TransactionStatus.INVALID
+  TransactionStatus.REJECTED
 ])
 
 const checkedTransactions = new Set<string>()

--- a/src/store/__tests__/modules/chat.test.js
+++ b/src/store/__tests__/modules/chat.test.js
@@ -1066,6 +1066,47 @@ describe('Store: chat.js', () => {
       })
     })
 
+    describe('mutations.updateCryptoTransferMessage', () => {
+      it('should update crypto transfer live status without changing chat ordering timestamp', () => {
+        const partnerId = 'U123456'
+        const originalTimestamp = 1_710_000_000_000
+        const messages = [
+          {
+            id: 'localId1',
+            hash: 'dash-hash',
+            timestamp: originalTimestamp,
+            status: TS.PENDING
+          }
+        ]
+        const state = {
+          chats: {
+            [partnerId]: {
+              messages
+            }
+          }
+        }
+
+        mutations.updateCryptoTransferMessage(state, {
+          partnerId,
+          hash: 'dash-hash',
+          status: TS.REGISTERED,
+          confirmations: 0,
+          instantsend: true
+        })
+
+        expect(messages).toEqual([
+          {
+            id: 'localId1',
+            hash: 'dash-hash',
+            timestamp: originalTimestamp,
+            status: TS.REGISTERED,
+            confirmations: 0,
+            instantsend: true
+          }
+        ])
+      })
+    })
+
     /**
      * mutations.createAdamantChats
      */

--- a/src/store/modules/chat/index.js
+++ b/src/store/modules/chat/index.js
@@ -562,6 +562,39 @@ const mutations = {
     }
   },
 
+  updateCryptoTransferMessage(
+    state,
+    { partnerId, hash, status, confirmations, instantlock, instantlock_internal, instantsend }
+  ) {
+    const chat = state.chats[partnerId]
+
+    if (!chat || !hash) {
+      return
+    }
+
+    const message = chat.messages.find((message) => message.hash === hash || message.id === hash)
+
+    if (!message) {
+      return
+    }
+
+    if (status) {
+      message.status = status
+    }
+    if (typeof confirmations === 'number') {
+      message.confirmations = confirmations
+    }
+    if (typeof instantlock === 'boolean') {
+      message.instantlock = instantlock
+    }
+    if (typeof instantlock_internal === 'boolean') {
+      message.instantlock_internal = instantlock_internal
+    }
+    if (typeof instantsend === 'boolean') {
+      message.instantsend = instantsend
+    }
+  },
+
   /**
    * Add `Welcome to ADAMANT` & `ADAMANT Tokens` to state.chats.
    */

--- a/src/store/modules/eth/offline-send-pipelines.spec.js
+++ b/src/store/modules/eth/offline-send-pipelines.spec.js
@@ -1,0 +1,268 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { privateKeyToAccount, TransactionFactory } from 'web3-eth-accounts'
+import { keccak256 } from 'web3-utils'
+
+const { ethApiMock, admNodeMock, pendingTransactionsMock } = vi.hoisted(() => ({
+  ethApiMock: {
+    assertAnyNodeOnline: vi.fn(),
+    getNonce: vi.fn(),
+    isTransactionFinalized: vi.fn(),
+    sendSignedTransaction: vi.fn(),
+    useClient: vi.fn(),
+    getClient: vi.fn(() => ({ provider: {} }))
+  },
+  admNodeMock: {
+    assertAnyNodeOnline: vi.fn()
+  },
+  pendingTransactionsMock: {
+    assertNoPendingTransaction: vi.fn(),
+    invalidatePendingTransaction: vi.fn(),
+    createPendingTransaction: vi.fn((value) => value),
+    PendingTxStore: {
+      get: vi.fn(),
+      save: vi.fn(),
+      remove: vi.fn()
+    }
+  }
+}))
+
+vi.mock('ecpair', () => ({
+  ECPairFactory: () => ({
+    fromPrivateKey: () => ({
+      publicKey: Buffer.alloc(33, 1)
+    }),
+    fromPublicKey: () => ({
+      verify: () => true
+    })
+  })
+}))
+
+vi.mock('tiny-secp256k1', () => ({}))
+
+vi.mock('@/store', () => ({
+  default: {
+    state: {},
+    getters: {},
+    commit: vi.fn(),
+    dispatch: vi.fn()
+  }
+}))
+
+vi.mock('@/lib/nodes', () => ({
+  nodes: {},
+  default: {},
+  adm: {},
+  btc: {},
+  dash: {},
+  doge: {},
+  eth: {},
+  ipfs: {}
+}))
+
+vi.mock('../../../lib/nodes/eth', () => ({
+  default: ethApiMock
+}))
+
+vi.mock('../../../lib/nodes/adm', () => ({
+  default: admNodeMock
+}))
+
+vi.mock('../../../lib/pending-transactions', () => pendingTransactionsMock)
+
+vi.mock('@/utils/devTools/logger', () => ({
+  logger: {
+    log: vi.fn()
+  }
+}))
+
+import actions from './actions'
+import stateFactory from './state'
+import mutations from './mutations'
+import getters from './getters'
+import erc20Module from '../erc20'
+import { CryptosInfo } from '@/lib/constants'
+import { toWei } from '@/lib/eth-utils'
+
+const TEST_PRIVATE_KEY = '0x4c0883a6910395b37d6231471b5dbb6204fe5129617082790f5ad3cbebd0c6f4'
+const ETH_RECIPIENT = '0x000000000000000000000000000000000000dEaD'
+
+function createCommitCollector() {
+  const commits = []
+
+  return {
+    commits,
+    commit(type, payload) {
+      commits.push({ type, payload })
+    }
+  }
+}
+
+function createTestAccount() {
+  const web3Account = privateKeyToAccount(TEST_PRIVATE_KEY)
+
+  return {
+    address: web3Account.address,
+    privateKey: TEST_PRIVATE_KEY,
+    web3Account
+  }
+}
+
+function createUseClientMock(estimateGasResult, estimatedTransactions) {
+  ethApiMock.useClient.mockImplementation(async (callback) =>
+    callback(() => ({
+      estimateGas: async (transaction) => {
+        estimatedTransactions.push({ ...transaction })
+        return estimateGasResult
+      }
+    }))
+  )
+}
+
+describe('offline ethereum-like send pipelines', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    ethApiMock.assertAnyNodeOnline.mockResolvedValue(undefined)
+    ethApiMock.getNonce.mockResolvedValue(7n)
+    ethApiMock.isTransactionFinalized.mockResolvedValue(false)
+    ethApiMock.sendSignedTransaction.mockImplementation(async (rawTransaction) =>
+      keccak256(rawTransaction)
+    )
+
+    pendingTransactionsMock.assertNoPendingTransaction.mockResolvedValue(undefined)
+    pendingTransactionsMock.invalidatePendingTransaction.mockResolvedValue(undefined)
+    pendingTransactionsMock.PendingTxStore.save.mockResolvedValue(undefined)
+  })
+
+  it('builds and signs an ETH transfer with the test account without broadcasting to a real node', async () => {
+    const state = stateFactory()
+    const account = createTestAccount()
+    const { commits, commit } = createCommitCollector()
+    const estimatedTransactions = []
+    const fromTxDataSpy = vi.spyOn(TransactionFactory, 'fromTxData')
+
+    mutations.account(state, account)
+    createUseClientMock(21_000n, estimatedTransactions)
+
+    const context = {
+      state,
+      getters: {
+        finalGasPrice: getters.finalGasPrice(state, {}, {}, { 'eth/gasPrice': state.gasPrice })
+      },
+      commit,
+      dispatch: vi.fn()
+    }
+
+    const hash = await actions.sendTokens(context, {
+      amount: 0.123456789,
+      address: ETH_RECIPIENT,
+      admAddress: '',
+      comments: '',
+      increaseFee: true,
+      replyToId: undefined
+    })
+
+    const unsignedTransaction = fromTxDataSpy.mock.calls[0][0]
+
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(estimatedTransactions[0]).toEqual({
+      from: state.address,
+      to: ETH_RECIPIENT,
+      value: BigInt(toWei(0.123456789)),
+      gasPrice: BigInt(context.getters.finalGasPrice(true)),
+      nonce: 7n
+    })
+    expect(unsignedTransaction).toMatchObject({
+      from: state.address,
+      to: ETH_RECIPIENT,
+      value: BigInt(toWei(0.123456789)),
+      gasPrice: BigInt(context.getters.finalGasPrice(true)),
+      nonce: 7n
+    })
+    expect(unsignedTransaction.gasLimit).toBeTypeOf('bigint')
+    expect(unsignedTransaction.gasLimit).toBeGreaterThan(21_000n)
+    expect(ethApiMock.sendSignedTransaction).toHaveBeenCalledTimes(1)
+    expect(pendingTransactionsMock.PendingTxStore.save).toHaveBeenCalledWith(
+      'ETH',
+      expect.objectContaining({
+        senderId: state.address,
+        recipientId: ETH_RECIPIENT,
+        nonce: 7
+      })
+    )
+    expect(commits).toContainEqual(
+      expect.objectContaining({
+        type: 'transactions',
+        payload: expect.arrayContaining([expect.objectContaining({ recipientId: ETH_RECIPIENT })])
+      })
+    )
+
+    fromTxDataSpy.mockRestore()
+  })
+
+  it('builds and signs a USDT transfer with contract calldata using the test account', async () => {
+    const usdtModule = erc20Module('USDT', CryptosInfo.USDT.contractId, CryptosInfo.USDT.decimals)
+    const state = usdtModule.state
+    const account = createTestAccount()
+    const estimatedTransactions = []
+    const fromTxDataSpy = vi.spyOn(TransactionFactory, 'fromTxData')
+
+    usdtModule.mutations.account(state, account)
+    createUseClientMock(65_000n, estimatedTransactions)
+
+    const context = {
+      state,
+      getters: {
+        finalGasPrice: usdtModule.getters.finalGasPrice(
+          state,
+          {},
+          {},
+          { 'eth/gasPrice': '1500000000' }
+        )
+      },
+      commit: vi.fn(),
+      dispatch: vi.fn()
+    }
+
+    const hash = await usdtModule.actions.sendTokens(context, {
+      amount: 12.345678,
+      address: ETH_RECIPIENT,
+      admAddress: '',
+      comments: '',
+      increaseFee: false,
+      replyToId: undefined
+    })
+
+    const unsignedTransaction = fromTxDataSpy.mock.calls[0][0]
+
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/)
+    expect(estimatedTransactions[0]).toMatchObject({
+      from: state.address,
+      to: state.contractAddress,
+      value: '0x0',
+      nonce: 7n
+    })
+    expect(estimatedTransactions[0].data).toMatch(/^0xa9059cbb/)
+    expect(unsignedTransaction).toMatchObject({
+      from: state.address,
+      to: state.contractAddress,
+      value: '0x0',
+      gasPrice: BigInt(context.getters.finalGasPrice(false)),
+      nonce: 7n
+    })
+    expect(unsignedTransaction.data).toMatch(/^0xa9059cbb/)
+    expect(unsignedTransaction.gasLimit).toBeTypeOf('bigint')
+    expect(unsignedTransaction.gasLimit).toBeGreaterThan(65_000n)
+    expect(ethApiMock.sendSignedTransaction).toHaveBeenCalledTimes(1)
+    expect(pendingTransactionsMock.PendingTxStore.save).toHaveBeenCalledWith(
+      'USDT',
+      expect.objectContaining({
+        senderId: state.address,
+        recipientId: ETH_RECIPIENT,
+        nonce: 7
+      })
+    )
+
+    fromTxDataSpy.mockRestore()
+  })
+})

--- a/src/views/AppSidebar.vue
+++ b/src/views/AppSidebar.vue
@@ -267,15 +267,54 @@ const hasFocusedEditableElement = () => {
   return activeElement.isContentEditable
 }
 
+const blurFocusedSendFundsField = () => {
+  const activeElement = document.activeElement
+
+  if (!(activeElement instanceof HTMLElement)) {
+    return false
+  }
+
+  const sendFundsForm = activeElement.closest('.send-funds-form')
+
+  if (!sendFundsForm) {
+    return false
+  }
+
+  const role = activeElement.getAttribute('role')
+  const isBlurCandidate =
+    activeElement instanceof HTMLInputElement ||
+    activeElement instanceof HTMLTextAreaElement ||
+    activeElement instanceof HTMLSelectElement ||
+    activeElement.isContentEditable ||
+    role === 'combobox' ||
+    role === 'textbox' ||
+    role === 'spinbutton'
+
+  if (!isBlurCandidate || typeof activeElement.blur !== 'function') {
+    return false
+  }
+
+  activeElement.blur()
+
+  return true
+}
+
 const onKeydownHandler = (e: KeyboardEvent) => {
-  if (
-    e.key !== 'Escape' ||
-    !canPressEscape.value ||
-    e.defaultPrevented ||
-    hasFocusedEditableElement() ||
-    hasActiveOverlay() ||
-    hasExpandedPopupActivator()
-  ) {
+  if (e.key !== 'Escape' || !canPressEscape.value || e.defaultPrevented) {
+    return
+  }
+
+  if (hasActiveOverlay()) {
+    return
+  }
+
+  if (blurFocusedSendFundsField()) {
+    e.preventDefault()
+    e.stopPropagation()
+    return
+  }
+
+  if (hasFocusedEditableElement() || hasExpandedPopupActivator()) {
     return
   }
 

--- a/src/views/__tests__/NavigationUiContract.spec.js
+++ b/src/views/__tests__/NavigationUiContract.spec.js
@@ -160,11 +160,17 @@ describe('Navigation UI style contract', () => {
     expect(content).toContain('document.querySelectorAll(\'[aria-expanded="true"]\')')
     expect(content).toContain("style.display !== 'none' && style.visibility !== 'hidden'")
     expect(content).toContain("element.getAttribute('role') === 'combobox'")
+    expect(content).toContain('const blurFocusedSendFundsField = () => {')
+    expect(content).toContain("const sendFundsForm = activeElement.closest('.send-funds-form')")
+    expect(content).toContain("role === 'spinbutton'")
+    expect(content).toContain('activeElement.blur()')
     expect(content).toContain("document.addEventListener('keydown', onKeydownHandler, true)")
     expect(content).toContain("document.removeEventListener('keydown', onKeydownHandler, true)")
-    expect(content).toContain(
-      'hasFocusedEditableElement() ||\n    hasActiveOverlay() ||\n    hasExpandedPopupActivator()'
-    )
+    expect(content).toContain('if (hasActiveOverlay()) {')
+    expect(content).toContain('if (blurFocusedSendFundsField()) {')
+    expect(content).toContain('e.preventDefault()')
+    expect(content).toContain('e.stopPropagation()')
+    expect(content).toContain('if (hasFocusedEditableElement() || hasExpandedPopupActivator()) {')
     expect(content).not.toContain('<router-view v-show="!showLogo" :key="route.path" />')
   })
 

--- a/tests/e2e/chat-attachment-modal-regression.spec.ts
+++ b/tests/e2e/chat-attachment-modal-regression.spec.ts
@@ -2,7 +2,6 @@ import { testPassphrase } from './helpers/env'
 import { expect, test, type Locator } from '@playwright/test'
 import { dismissAddressWarningIfVisible, loginWithPassphrase } from './helpers/auth'
 
-const testChatId = 'U6386412615727665758'
 const activeImageSlideSelector =
   '.v-window-item--active.a-chat-image-modal-item, .v-window-item--active .a-chat-image-modal-item'
 type PreviewTarget = 'incoming-latest' | 'outgoing-before-incoming'
@@ -11,15 +10,113 @@ test.describe('Chat attachment modal regressions', () => {
   test('closes image modal even on near-edge backdrop clicks for different image aspect ratios', async ({
     page
   }) => {
-    test.setTimeout(180_000)
+    test.setTimeout(240_000)
     test.skip(!testPassphrase, 'Requires ADM_TEST_ACCOUNT_PK in .env.local')
 
     await loginWithPassphrase(page, testPassphrase!)
 
     const modal = page.locator('.a-chat-image-modal__container')
+    let targetChatPath: string | null = null
+
+    const findChatWithMixedImagePreviews = async () => {
+      await page.goto('/chats')
+      await expect(page).toHaveURL(/\/chats$/)
+      await dismissAddressWarningIfVisible(page, 12_000)
+
+      const chatItems = page.locator('.chats-view__messages--chat .v-list-item')
+      await expect(chatItems.first()).toBeVisible({ timeout: 15_000 })
+      const visibleCount = await chatItems.count()
+      const maxChatsToInspect = Math.min(visibleCount, 12)
+      const preferredIndexes: number[] = []
+      const fallbackIndexes: number[] = []
+
+      for (let index = 0; index < maxChatsToInspect; index += 1) {
+        const itemText = (
+          (await chatItems
+            .nth(index)
+            .textContent()
+            .catch(() => '')) ?? ''
+        ).trim()
+
+        if (/Attached:/i.test(itemText)) {
+          preferredIndexes.push(index)
+        } else {
+          fallbackIndexes.push(index)
+        }
+      }
+
+      const indexesToInspect = [...preferredIndexes, ...fallbackIndexes]
+
+      for (const index of indexesToInspect) {
+        await page.goto('/chats')
+        await expect(page).toHaveURL(/\/chats$/)
+        await dismissAddressWarningIfVisible(page, 3_000)
+        await expect(chatItems.first()).toBeVisible({ timeout: 15_000 })
+
+        const chatItem = chatItems.nth(index)
+        await chatItem.click()
+        await page.waitForURL(/\/chats\/[^/?#]+$/, { timeout: 90_000 })
+        await dismissAddressWarningIfVisible(page, 3_000)
+
+        const chatPath = new URL(page.url()).pathname
+        if (!chatPath.startsWith('/chats/')) {
+          continue
+        }
+
+        const messagesContainer = page.locator('.a-chat__body-messages').first()
+        await expect(messagesContainer).toBeVisible()
+
+        await messagesContainer.evaluate((element) => {
+          element.scrollTop = element.scrollHeight
+        })
+        await page.waitForTimeout(350)
+
+        for (let attempt = 1; attempt <= 18; attempt += 1) {
+          const previewStats = await messagesContainer.evaluate((container) => {
+            const previews = Array.from(
+              container.querySelectorAll('.a-chat__attachments .v-img')
+            ).map((preview) => {
+              const messageContainer = preview.closest('.a-chat__message-container')
+              return {
+                incoming:
+                  !(messageContainer instanceof HTMLElement) ||
+                  !messageContainer.classList.contains('a-chat__message-container--right'),
+                outgoing:
+                  messageContainer instanceof HTMLElement &&
+                  messageContainer.classList.contains('a-chat__message-container--right')
+              }
+            })
+
+            return {
+              incoming: previews.filter((item) => item.incoming).length,
+              outgoing: previews.filter((item) => item.outgoing).length
+            }
+          })
+
+          if (previewStats.incoming > 0 && previewStats.outgoing > 0) {
+            return chatPath
+          }
+
+          await messagesContainer.evaluate((element) => {
+            const step = Math.max(260, Math.floor(element.clientHeight * 0.9))
+            element.scrollTop = Math.max(0, element.scrollTop - step)
+          })
+          await page.waitForTimeout(450)
+        }
+      }
+
+      throw new Error('Failed to find a chat with both incoming and outgoing image previews')
+    }
+
     const openTargetChat = async () => {
-      await page.goto(`/chats/${testChatId}`)
-      await page.waitForURL(new RegExp(`/chats/${testChatId}$`), { timeout: 90_000 })
+      if (!targetChatPath) {
+        targetChatPath = await findChatWithMixedImagePreviews()
+      }
+
+      await page.goto(targetChatPath)
+      await page.waitForURL(new RegExp(`${targetChatPath.replace('/', '\\/')}$`), {
+        timeout: 90_000
+      })
       await dismissAddressWarningIfVisible(page, 12_000)
 
       const messagesContainer = page.locator('.a-chat__body-messages').first()
@@ -139,7 +236,7 @@ test.describe('Chat attachment modal regressions', () => {
       }, activeImageSlideSelector)
 
     const resolveTargetPreview = async (messagesContainer: Locator, target: PreviewTarget) => {
-      const maxAttempts = 8
+      const maxAttempts = 20
 
       for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
         if ((await messagesContainer.count()) === 0) {
@@ -199,15 +296,15 @@ test.describe('Chat attachment modal regressions', () => {
 
         if (targetIndex !== null) {
           const locator = messagesContainer.locator('.a-chat__attachments .v-img').nth(targetIndex)
-          await expect(locator).toBeVisible({ timeout: 8_000 })
+          await expect(locator).toBeVisible({ timeout: 12_000 })
           return locator
         }
 
         await messagesContainer.evaluate((element) => {
-          const step = Math.max(180, Math.floor(element.clientHeight * 0.6))
+          const step = Math.max(260, Math.floor(element.clientHeight * 0.9))
           element.scrollTop = Math.max(0, element.scrollTop - step)
         })
-        await page.waitForTimeout(220)
+        await page.waitForTimeout(500)
       }
 
       throw new Error(`Failed to resolve preview target: ${target}`)
@@ -215,13 +312,6 @@ test.describe('Chat attachment modal regressions', () => {
 
     const assertNearRightBackdropClosesModal = async (target: PreviewTarget) => {
       const messagesContainer = await openTargetChat()
-
-      // Make sure the message feed is hydrated before selecting target image previews.
-      await expect
-        .poll(async () => await messagesContainer.locator('.a-chat__attachments .v-img').count(), {
-          timeout: 15_000
-        })
-        .toBeGreaterThan(0)
 
       await openPreviewModal(messagesContainer, target)
 
@@ -267,20 +357,43 @@ test.describe('Chat attachment modal regressions', () => {
 
       const viewport = page.viewportSize()
       expect(viewport).not.toBeNull()
+      const scrim = page.locator('.v-overlay__scrim').last()
+      await expect(scrim).toBeVisible()
 
       const messagesContainerBox = await messagesContainer.boundingBox()
       const paneLeft = messagesContainerBox ? Math.round(messagesContainerBox.x) : 0
+      const modalBox = await modal.boundingBox()
+      const scrimBox = await scrim.boundingBox()
+      expect(modalBox).not.toBeNull()
+      expect(scrimBox).not.toBeNull()
+      if (!modalBox || !scrimBox) return
 
-      let nearRightX = Math.round(activeImageRect.right + 4)
-      if (nearRightX > (viewport?.width ?? 1280) - 4) {
-        nearRightX = Math.max(paneLeft + 4, Math.round(activeImageRect.left - 4))
-      }
+      const viewportWidth = viewport?.width ?? 1280
+      const modalLeft = modalBox.x
+      const modalRight = modalBox.x + modalBox.width
+      const rightBackdropSpace = Math.max(0, viewportWidth - modalRight - 8)
+      const leftBackdropSpace = Math.max(0, modalLeft - paneLeft - 8)
+
+      let nearRightX =
+        rightBackdropSpace >= 12
+          ? Math.round(modalRight + Math.min(Math.max(16, rightBackdropSpace / 2), 80))
+          : Math.max(
+              paneLeft + 8,
+              Math.round(modalLeft - Math.min(Math.max(16, leftBackdropSpace / 2), 80))
+            )
+
       const nearRightBackdropPoint = {
         x: nearRightX,
         y: centerPoint.y
       }
 
-      await page.mouse.click(nearRightBackdropPoint.x, nearRightBackdropPoint.y)
+      await scrim.click({
+        force: true,
+        position: {
+          x: Math.max(8, Math.min(scrimBox.width - 8, nearRightBackdropPoint.x - scrimBox.x)),
+          y: Math.max(8, Math.min(scrimBox.height - 8, nearRightBackdropPoint.y - scrimBox.y))
+        }
+      })
       await expect(modal).toBeHidden()
     }
 

--- a/tests/e2e/chat-attachment-modal-regression.spec.ts
+++ b/tests/e2e/chat-attachment-modal-regression.spec.ts
@@ -4,7 +4,13 @@ import { dismissAddressWarningIfVisible, loginWithPassphrase } from './helpers/a
 
 const activeImageSlideSelector =
   '.v-window-item--active.a-chat-image-modal-item, .v-window-item--active .a-chat-image-modal-item'
-type PreviewTarget = 'incoming-latest' | 'outgoing-before-incoming'
+
+type PreviewTarget = 'latest' | 'previous'
+
+type PreviewCase = {
+  chatPath: string
+  target: PreviewTarget
+}
 
 test.describe('Chat attachment modal regressions', () => {
   test('closes image modal even on near-edge backdrop clicks for different image aspect ratios', async ({
@@ -16,45 +22,44 @@ test.describe('Chat attachment modal regressions', () => {
     await loginWithPassphrase(page, testPassphrase!)
 
     const modal = page.locator('.a-chat-image-modal__container')
-    let targetChatPath: string | null = null
+    const modalContent = page.locator('.a-chat-image-modal__content')
 
-    const findChatWithMixedImagePreviews = async () => {
+    const findPreviewCases = async () => {
       await page.goto('/chats')
       await expect(page).toHaveURL(/\/chats$/)
       await dismissAddressWarningIfVisible(page, 12_000)
 
       const chatItems = page.locator('.chats-view__messages--chat .v-list-item')
       await expect(chatItems.first()).toBeVisible({ timeout: 15_000 })
+
       const visibleCount = await chatItems.count()
-      const maxChatsToInspect = Math.min(visibleCount, 12)
+      const maxChatsToInspect = Math.min(visibleCount, 16)
       const preferredIndexes: number[] = []
       const fallbackIndexes: number[] = []
+      const cases: PreviewCase[] = []
 
       for (let index = 0; index < maxChatsToInspect; index += 1) {
-        const itemText = (
+        const text = (
           (await chatItems
             .nth(index)
             .textContent()
             .catch(() => '')) ?? ''
         ).trim()
 
-        if (/Attached:/i.test(itemText)) {
+        if (/Attached:/i.test(text)) {
           preferredIndexes.push(index)
         } else {
           fallbackIndexes.push(index)
         }
       }
 
-      const indexesToInspect = [...preferredIndexes, ...fallbackIndexes]
-
-      for (const index of indexesToInspect) {
+      for (const index of [...preferredIndexes, ...fallbackIndexes]) {
         await page.goto('/chats')
         await expect(page).toHaveURL(/\/chats$/)
         await dismissAddressWarningIfVisible(page, 3_000)
         await expect(chatItems.first()).toBeVisible({ timeout: 15_000 })
 
-        const chatItem = chatItems.nth(index)
-        await chatItem.click()
+        await chatItems.nth(index).click()
         await page.waitForURL(/\/chats\/[^/?#]+$/, { timeout: 90_000 })
         await dismissAddressWarningIfVisible(page, 3_000)
 
@@ -65,36 +70,18 @@ test.describe('Chat attachment modal regressions', () => {
 
         const messagesContainer = page.locator('.a-chat__body-messages').first()
         await expect(messagesContainer).toBeVisible()
-
         await messagesContainer.evaluate((element) => {
           element.scrollTop = element.scrollHeight
         })
         await page.waitForTimeout(350)
 
+        let previewCount = 0
+
         for (let attempt = 1; attempt <= 18; attempt += 1) {
-          const previewStats = await messagesContainer.evaluate((container) => {
-            const previews = Array.from(
-              container.querySelectorAll('.a-chat__attachments .v-img')
-            ).map((preview) => {
-              const messageContainer = preview.closest('.a-chat__message-container')
-              return {
-                incoming:
-                  !(messageContainer instanceof HTMLElement) ||
-                  !messageContainer.classList.contains('a-chat__message-container--right'),
-                outgoing:
-                  messageContainer instanceof HTMLElement &&
-                  messageContainer.classList.contains('a-chat__message-container--right')
-              }
-            })
+          previewCount = await messagesContainer.locator('.a-chat__attachments .v-img').count()
 
-            return {
-              incoming: previews.filter((item) => item.incoming).length,
-              outgoing: previews.filter((item) => item.outgoing).length
-            }
-          })
-
-          if (previewStats.incoming > 0 && previewStats.outgoing > 0) {
-            return chatPath
+          if (previewCount > 0) {
+            break
           }
 
           await messagesContainer.evaluate((element) => {
@@ -103,18 +90,32 @@ test.describe('Chat attachment modal regressions', () => {
           })
           await page.waitForTimeout(450)
         }
+
+        if (previewCount > 0) {
+          cases.push({ chatPath, target: 'latest' })
+
+          if (previewCount > 1) {
+            cases.push({ chatPath, target: 'previous' })
+          }
+        }
+
+        if (cases.length >= 6) {
+          return cases
+        }
       }
 
-      throw new Error('Failed to find a chat with both incoming and outgoing image previews')
+      if (cases.length > 0) {
+        return cases
+      }
+
+      throw new Error('Failed to find chats with image previews')
     }
 
-    const openTargetChat = async () => {
-      if (!targetChatPath) {
-        targetChatPath = await findChatWithMixedImagePreviews()
-      }
+    const previewCases = await findPreviewCases()
 
-      await page.goto(targetChatPath)
-      await page.waitForURL(new RegExp(`${targetChatPath.replace('/', '\\/')}$`), {
+    const openTargetChat = async (chatPath: string) => {
+      await page.goto(chatPath)
+      await page.waitForURL(new RegExp(`${chatPath.replace('/', '\\/')}$`), {
         timeout: 90_000
       })
       await dismissAddressWarningIfVisible(page, 12_000)
@@ -127,6 +128,46 @@ test.describe('Chat attachment modal regressions', () => {
       await page.waitForTimeout(300)
 
       return messagesContainer
+    }
+
+    const resolveTargetPreview = async (messagesContainer: Locator, target: PreviewTarget) => {
+      const maxAttempts = 20
+
+      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+        const previews = await messagesContainer.locator('.a-chat__attachments .v-img').count()
+
+        if (previews > 0) {
+          const orderedIndexes = await messagesContainer.evaluate((container) => {
+            return Array.from(container.querySelectorAll('.a-chat__attachments .v-img'))
+              .map((preview, index) => ({
+                index,
+                top: preview.getBoundingClientRect().top
+              }))
+              .filter((item) => Number.isFinite(item.top))
+              .sort((a, b) => b.top - a.top)
+              .map((item) => item.index)
+          })
+
+          const targetIndex =
+            target === 'previous' ? (orderedIndexes[1] ?? orderedIndexes[0]) : orderedIndexes[0]
+
+          if (typeof targetIndex === 'number') {
+            const locator = messagesContainer
+              .locator('.a-chat__attachments .v-img')
+              .nth(targetIndex)
+            await expect(locator).toBeVisible({ timeout: 12_000 })
+            return locator
+          }
+        }
+
+        await messagesContainer.evaluate((element) => {
+          const step = Math.max(260, Math.floor(element.clientHeight * 0.9))
+          element.scrollTop = Math.max(0, element.scrollTop - step)
+        })
+        await page.waitForTimeout(500)
+      }
+
+      throw new Error(`Failed to resolve preview target: ${target}`)
     }
 
     const openPreviewModal = async (messagesContainer: Locator, target: PreviewTarget) => {
@@ -160,8 +201,6 @@ test.describe('Chat attachment modal regressions', () => {
 
       return 1
     }
-
-    let surfaceChecked = false
 
     const getActiveImageRect = async () =>
       page.evaluate((selector) => {
@@ -235,85 +274,29 @@ test.describe('Chat attachment modal regressions', () => {
         }
       }, activeImageSlideSelector)
 
-    const resolveTargetPreview = async (messagesContainer: Locator, target: PreviewTarget) => {
-      const maxAttempts = 20
+    const getRightGutterPoint = (
+      imageRect: { left: number; right: number; top: number; bottom: number },
+      contentRect: { x: number; y: number; width: number; height: number }
+    ) => {
+      const modalRight = contentRect.x + contentRect.width
+      const imageCenterY = Math.round((imageRect.top + imageRect.bottom) / 2)
+      const rightGutter = modalRight - imageRect.right
 
-      for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
-        if ((await messagesContainer.count()) === 0) {
-          await openTargetChat()
-          continue
-        }
-
-        let targetIndex: number | null = null
-
-        try {
-          targetIndex = await messagesContainer.evaluate(
-            (container, targetName: PreviewTarget) => {
-              const previews = Array.from(container.querySelectorAll('.a-chat__attachments .v-img'))
-                .map((preview, index) => {
-                  const messageContainer = preview.closest('.a-chat__message-container')
-                  const timestamp = messageContainer
-                    ?.querySelector('.a-chat__timestamp')
-                    ?.textContent?.trim()
-                  const rect = preview.getBoundingClientRect()
-
-                  return {
-                    index,
-                    top: rect.top,
-                    outgoing:
-                      messageContainer?.classList.contains('a-chat__message-container--right') ??
-                      false,
-                    timestamp
-                  }
-                })
-                .filter((item) => Number.isFinite(item.top))
-                .sort((a, b) => b.top - a.top)
-
-              const latestIncoming = previews.find((item) => !item.outgoing)
-              const outgoingByKnownTimestamp = previews.find(
-                (item) => item.outgoing && item.timestamp?.includes('07:43')
-              )
-              const outgoingBeforeIncoming = latestIncoming
-                ? previews.find((item) => item.outgoing && item.top < latestIncoming.top - 1)
-                : undefined
-
-              const chosen =
-                targetName === 'incoming-latest'
-                  ? latestIncoming
-                  : (outgoingByKnownTimestamp ??
-                    outgoingBeforeIncoming ??
-                    previews.find((item) => item.outgoing))
-
-              return typeof chosen?.index === 'number' ? chosen.index : null
-            },
-            target,
-            { timeout: 8_000 }
-          )
-        } catch {
-          await openTargetChat()
-          continue
-        }
-
-        if (targetIndex !== null) {
-          const locator = messagesContainer.locator('.a-chat__attachments .v-img').nth(targetIndex)
-          await expect(locator).toBeVisible({ timeout: 12_000 })
-          return locator
-        }
-
-        await messagesContainer.evaluate((element) => {
-          const step = Math.max(260, Math.floor(element.clientHeight * 0.9))
-          element.scrollTop = Math.max(0, element.scrollTop - step)
-        })
-        await page.waitForTimeout(500)
+      if (rightGutter < 16) {
+        return null
       }
 
-      throw new Error(`Failed to resolve preview target: ${target}`)
+      return {
+        x: Math.round(imageRect.right + Math.max(10, rightGutter / 2)),
+        y: imageCenterY
+      }
     }
 
-    const assertNearRightBackdropClosesModal = async (target: PreviewTarget) => {
-      const messagesContainer = await openTargetChat()
+    let surfaceChecked = false
 
-      await openPreviewModal(messagesContainer, target)
+    const assertBackdropClickClosesModal = async (previewCase: PreviewCase) => {
+      const messagesContainer = await openTargetChat(previewCase.chatPath)
+      await openPreviewModal(messagesContainer, previewCase.target)
 
       if (!surfaceChecked) {
         const surfaces = await page.evaluate(() => {
@@ -339,7 +322,6 @@ test.describe('Chat attachment modal regressions', () => {
         }
 
         expect(surfaces.scrimBackdropFilter).toContain('blur(')
-
         surfaceChecked = true
       }
 
@@ -347,59 +329,48 @@ test.describe('Chat attachment modal regressions', () => {
       expect(activeImageRect).not.toBeNull()
       if (!activeImageRect) return
 
-      const centerPoint = {
+      const imageCenter = {
         x: Math.round((activeImageRect.left + activeImageRect.right) / 2),
         y: Math.round((activeImageRect.top + activeImageRect.bottom) / 2)
       }
 
-      await page.mouse.click(centerPoint.x, centerPoint.y)
+      await page.mouse.click(imageCenter.x, imageCenter.y)
       await expect(modal).toBeVisible()
 
-      const viewport = page.viewportSize()
-      expect(viewport).not.toBeNull()
-      const scrim = page.locator('.v-overlay__scrim').last()
-      await expect(scrim).toBeVisible()
+      const contentBox = await modalContent.boundingBox()
+      expect(contentBox).not.toBeNull()
+      if (!contentBox) return
 
-      const messagesContainerBox = await messagesContainer.boundingBox()
-      const paneLeft = messagesContainerBox ? Math.round(messagesContainerBox.x) : 0
-      const modalBox = await modal.boundingBox()
-      const scrimBox = await scrim.boundingBox()
-      expect(modalBox).not.toBeNull()
-      expect(scrimBox).not.toBeNull()
-      if (!modalBox || !scrimBox) return
-
-      const viewportWidth = viewport?.width ?? 1280
-      const modalLeft = modalBox.x
-      const modalRight = modalBox.x + modalBox.width
-      const rightBackdropSpace = Math.max(0, viewportWidth - modalRight - 8)
-      const leftBackdropSpace = Math.max(0, modalLeft - paneLeft - 8)
-
-      let nearRightX =
-        rightBackdropSpace >= 12
-          ? Math.round(modalRight + Math.min(Math.max(16, rightBackdropSpace / 2), 80))
-          : Math.max(
-              paneLeft + 8,
-              Math.round(modalLeft - Math.min(Math.max(16, leftBackdropSpace / 2), 80))
-            )
-
-      const nearRightBackdropPoint = {
-        x: nearRightX,
-        y: centerPoint.y
+      const gutterPoint = getRightGutterPoint(activeImageRect, contentBox)
+      if (!gutterPoint) {
+        await page.keyboard.press('Escape').catch(() => undefined)
+        await expect(modal).toBeHidden()
+        return false
       }
 
-      await scrim.click({
+      await modalContent.click({
         force: true,
         position: {
-          x: Math.max(8, Math.min(scrimBox.width - 8, nearRightBackdropPoint.x - scrimBox.x)),
-          y: Math.max(8, Math.min(scrimBox.height - 8, nearRightBackdropPoint.y - scrimBox.y))
+          x: Math.max(8, Math.min(contentBox.width - 8, gutterPoint.x - contentBox.x)),
+          y: Math.max(8, Math.min(contentBox.height - 8, gutterPoint.y - contentBox.y))
         }
       })
       await expect(modal).toBeHidden()
+      return true
     }
 
-    // Latest incoming image with cats
-    await assertNearRightBackdropClosesModal('incoming-latest')
-    // Previous outgoing image around 07:43 with different aspect ratio
-    await assertNearRightBackdropClosesModal('outgoing-before-incoming')
+    let successfulCases = 0
+
+    for (const previewCase of previewCases) {
+      if (await assertBackdropClickClosesModal(previewCase)) {
+        successfulCases += 1
+      }
+
+      if (successfulCases >= 2) {
+        break
+      }
+    }
+
+    expect(successfulCases).toBeGreaterThanOrEqual(2)
   })
 })

--- a/tests/e2e/chat-btc-live-pending-visual.spec.ts
+++ b/tests/e2e/chat-btc-live-pending-visual.spec.ts
@@ -1,0 +1,246 @@
+import { createHash } from 'node:crypto'
+import { expect, test, type Page } from '@playwright/test'
+import { loginWithPassphrase } from './helpers/auth'
+import { testPassphrase } from './helpers/env'
+
+const LIVE_TIMEOUT = 120_000
+const RECIPIENT_ADM = 'U6386412615727665758'
+const PENDING_TRANSACTION_STORAGE_KEY = 'PENDING_TRANSACTIONS'
+const KEEP_OPEN = process.env.PLAYWRIGHT_KEEP_OPEN === '1'
+
+const waitForBtcWalletReady = async (page: Page) => {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(() => {
+          const runtime = window as Window & {
+            store?: {
+              state: Record<string, any>
+            }
+          }
+          const store = runtime.store
+
+          if (!store) {
+            throw new Error('window.store is not available')
+          }
+
+          return {
+            address: String(store.state.btc?.address ?? ''),
+            balanceStatus: String(store.state.btc?.balanceStatus ?? '')
+          }
+        }),
+      { timeout: LIVE_TIMEOUT }
+    )
+    .toMatchObject({
+      balanceStatus: 'success'
+    })
+
+  return page.evaluate(() => {
+    const runtime = window as Window & {
+      store?: {
+        state: Record<string, any>
+      }
+    }
+    const store = runtime.store
+
+    if (!store) {
+      throw new Error('window.store is not available')
+    }
+
+    return {
+      admAddress: String(store.state.address ?? ''),
+      btcAddress: String(store.state.btc?.address ?? '')
+    }
+  })
+}
+
+const sendFraudBtcTransferMessage = async (
+  page: Page,
+  {
+    hash,
+    amount,
+    comments
+  }: {
+    hash: string
+    amount: string
+    comments: string
+  }
+) => {
+  const success = await page.evaluate(
+    async ({ recipientId, hash, amount, comments }) => {
+      const runtime = window as Window & {
+        store?: {
+          dispatch: (type: string, payload?: unknown) => Promise<unknown>
+        }
+      }
+      const store = runtime.store
+
+      if (!store) {
+        throw new Error('window.store is not available')
+      }
+
+      return store.dispatch('sendCryptoTransferMessage', {
+        address: recipientId,
+        crypto: 'BTC',
+        amount,
+        hash,
+        comments
+      })
+    },
+    {
+      recipientId: RECIPIENT_ADM,
+      hash,
+      amount,
+      comments
+    }
+  )
+
+  expect(success).toBe(true)
+}
+
+const saveBrowserPendingBtc = async (
+  page: Page,
+  {
+    hash,
+    senderId,
+    recipientId,
+    amount
+  }: {
+    hash: string
+    senderId: string
+    recipientId: string
+    amount: number
+  }
+) => {
+  await page.evaluate(
+    ({ hash, senderId, recipientId, amount, storageKey }) => {
+      const rawState = window.sessionStorage.getItem(storageKey)
+      const state = rawState ? JSON.parse(rawState) : {}
+
+      state.BTC = {
+        id: hash,
+        hash,
+        senderId,
+        recipientId,
+        amount,
+        fee: 0,
+        status: 'PENDING',
+        direction: 'from',
+        timestamp: Date.now()
+      }
+
+      window.sessionStorage.setItem(storageKey, JSON.stringify(state))
+    },
+    {
+      hash,
+      senderId,
+      recipientId,
+      amount,
+      storageKey: PENDING_TRANSACTION_STORAGE_KEY
+    }
+  )
+}
+
+const getChatTransferStatus = async (page: Page, comments: string) => {
+  return page.evaluate(
+    ({ partnerId, comments }) => {
+      const runtime = window as Window & {
+        store?: {
+          state: Record<string, any>
+        }
+      }
+      const store = runtime.store
+
+      if (!store) {
+        throw new Error('window.store is not available')
+      }
+
+      const messages = store.state.chat?.chats?.[partnerId]?.messages ?? []
+      const transaction = [...messages]
+        .reverse()
+        .find(
+          (message: Record<string, any>) =>
+            message.type === 'BTC' && String(message.message) === comments
+        )
+
+      return transaction
+        ? {
+            id: String(transaction.id ?? ''),
+            hash: String(transaction.hash ?? ''),
+            status: String(transaction.status ?? ''),
+            message: String(transaction.message ?? '')
+          }
+        : null
+    },
+    { partnerId: RECIPIENT_ADM, comments }
+  )
+}
+
+test.describe('Live BTC pending chat status', () => {
+  test('keeps a newly sent invalid BTC rich message pending in the live browser session when browser PendingTxStore knows it', async ({
+    page
+  }) => {
+    test.skip(!testPassphrase, 'Requires ADM_TEST_ACCOUNT_PK in .env.local')
+
+    test.slow()
+
+    await loginWithPassphrase(page, testPassphrase!)
+
+    const { admAddress, btcAddress } = await waitForBtcWalletReady(page)
+    expect(admAddress).not.toBe('')
+    expect(btcAddress).not.toBe('')
+
+    await page.goto(`/chats/${RECIPIENT_ADM}`, { waitUntil: 'domcontentloaded' })
+    await expect(page).toHaveURL(new RegExp(`/chats/${RECIPIENT_ADM}$`))
+    await expect(page.locator('.a-chat__body-messages').first()).toBeVisible()
+
+    const hash = createHash('sha256')
+      .update(`playwright-live-btc-pending-${Date.now()}`)
+      .digest('hex')
+    const comments = `Playwright live BTC pending ${Date.now()}`
+
+    await saveBrowserPendingBtc(page, {
+      hash,
+      senderId: btcAddress,
+      recipientId: btcAddress,
+      amount: 1
+    })
+
+    await sendFraudBtcTransferMessage(page, {
+      hash,
+      amount: '1',
+      comments
+    })
+
+    await expect
+      .poll(() => getChatTransferStatus(page, comments), {
+        timeout: LIVE_TIMEOUT
+      })
+      .toMatchObject({
+        hash,
+        status: 'PENDING'
+      })
+
+    const messageBody = page
+      .locator('.a-chat__message-card-body')
+      .filter({ hasText: comments })
+      .last()
+    await expect(messageBody).toBeVisible({ timeout: LIVE_TIMEOUT })
+
+    await page.waitForTimeout(6_000)
+
+    await expect
+      .poll(() => getChatTransferStatus(page, comments), {
+        timeout: 15_000
+      })
+      .toMatchObject({
+        hash,
+        status: 'PENDING'
+      })
+
+    if (KEEP_OPEN) {
+      await page.pause()
+      await new Promise(() => {})
+    }
+  })
+})

--- a/tests/e2e/helpers/auth.ts
+++ b/tests/e2e/helpers/auth.ts
@@ -46,9 +46,19 @@ export const loginWithNewAccount = async (page: Page) => {
 }
 
 export const loginWithPassphrase = async (page: Page, passphrase: string) => {
-  await page.goto('/')
+  await page.goto('/', { waitUntil: 'domcontentloaded' })
 
   const loginInput = page.locator('input[autocomplete="current-password"]')
+
+  if (!(await loginInput.isVisible().catch(() => false))) {
+    const currentPath = new URL(page.url()).pathname
+
+    if (/^\/(?:chats|home|account|settings|transfer)(?:\/.*)?$/.test(currentPath)) {
+      await dismissAddressWarningIfVisible(page, 8_000)
+      return
+    }
+  }
+
   await expect(loginInput).toBeVisible()
   await loginInput.fill(passphrase)
 

--- a/tests/e2e/helpers/openTransactionListFromHome.ts
+++ b/tests/e2e/helpers/openTransactionListFromHome.ts
@@ -1,8 +1,11 @@
 import { expect, type Page } from '@playwright/test'
 
+import { dismissAddressWarningIfVisible } from './auth'
+
 export const openTransactionListFromHome = async (page: Page, crypto: string) => {
   await page.goto('/home', { waitUntil: 'domcontentloaded' })
   await expect(page).toHaveURL(/\/home(?:\/)?$/)
+  await dismissAddressWarningIfVisible(page, 8_000)
 
   const activeWalletTab = page.locator('[role="tab"][aria-selected="true"]').first()
   const activeTabText = (await activeWalletTab.textContent())?.trim() ?? ''

--- a/tests/e2e/send-funds-layout-regression.spec.ts
+++ b/tests/e2e/send-funds-layout-regression.spec.ts
@@ -152,6 +152,47 @@ test.describe('Transfer layout regressions', () => {
     ).toBeHidden()
     expect(routerWarnings).toEqual([])
 
+    const activeElementAfterClose = await page.evaluate(() => {
+      const activeElement = document.activeElement as HTMLElement | null
+      return activeElement?.getAttribute('role') || activeElement?.tagName || ''
+    })
+
+    expect(activeElementAfterClose.toLowerCase()).toContain('combobox')
+
+    await page.keyboard.press('Escape')
+    await expect(page).toHaveURL(/\/transfer(?:\/)?$/)
+
+    const sendFundsFieldStillFocused = await page.evaluate(() => {
+      const activeElement = document.activeElement as HTMLElement | null
+      return !!activeElement?.closest('.send-funds-form .v-input')
+    })
+
+    expect(sendFundsFieldStillFocused).toBe(false)
+
+    await page.keyboard.press('Escape')
+    await expect(page).not.toHaveURL(/\/transfer(?:\/)?$/)
+
+    await assertNoDocumentScrollLeak(page)
+  })
+
+  test('blurs amount field on first Escape before leaving send funds screen', async ({ page }) => {
+    await loginWithNewAccount(page)
+
+    await page.goto('/transfer')
+    await expect(page).toHaveURL(/\/transfer(?:\/)?$/)
+    await expect(page.locator('.send-funds-form')).toBeVisible()
+
+    const amountInput = page.locator('.send-funds-form__amount-input input')
+    await amountInput.click()
+    await expect(amountInput).toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(page).toHaveURL(/\/transfer(?:\/)?$/)
+    await expect(amountInput).not.toBeFocused()
+
+    await page.keyboard.press('Escape')
+    await expect(page).not.toHaveURL(/\/transfer(?:\/)?$/)
+
     await assertNoDocumentScrollLeak(page)
   })
 

--- a/tests/e2e/send-funds-live-account.spec.ts
+++ b/tests/e2e/send-funds-live-account.spec.ts
@@ -1,0 +1,399 @@
+import { expect, test, type Page } from '@playwright/test'
+import { loginWithPassphrase } from './helpers/auth'
+import { testPassphrase } from './helpers/env'
+
+const LIVE_TIMEOUT = 120_000
+
+const recipients = {
+  ADM: 'U12345678901234567890',
+  BTC: 'bc1ql3e9pgs3mmwuwrh95fecme0s0qtn2880lsvsd5',
+  ETH: '0x000000000000000000000000000000000000dEaD',
+  USDT: '0x000000000000000000000000000000000000dEaD',
+  DOGE: 'DU9umLs2Ze8eNRo69wbSj5HeufphJawFPh',
+  DASH: 'Xyhf4LaHDwSwzND5HEv72qoqrsg625rCMt'
+} as const
+
+const dustAmounts = {
+  ADM: '0.0000000001',
+  BTC: '0.0000000001',
+  ETH: '0.0000000001',
+  USDT: '0.0000001',
+  DOGE: '0.5',
+  DASH: '0.000001'
+} as const
+
+const spendableCryptos = ['ADM', 'BTC', 'ETH', 'USDT', 'DOGE', 'DASH'] as const
+
+type SpendableCrypto = (typeof spendableCryptos)[number]
+
+type RuntimeWalletState = {
+  address: string
+  balance: number
+  balanceStatus: string
+  ready: boolean
+  feeRate?: number
+  utxoCount?: number
+}
+
+type SendFundsSnapshot = {
+  allowIncreaseFee: boolean
+  amountString: string
+  balance: number
+  cryptoAddress: string
+  currency: string
+  dialog: boolean
+  estimatedGasLimit: number | null
+  exponent: number
+  increaseFee: boolean
+  maxToTransfer: number
+  minToTransfer: number
+  transferFee: number
+}
+
+const getRuntimeWalletState = async (
+  page: Page,
+  crypto: SpendableCrypto
+): Promise<RuntimeWalletState> => {
+  return page.evaluate((symbol) => {
+    const runtime = window as Window & {
+      store?: {
+        state: Record<string, any>
+      }
+    }
+    const store = runtime.store
+
+    if (!store) {
+      throw new Error('window.store is not available')
+    }
+
+    if (symbol === 'ADM') {
+      return {
+        address: store.state.address ?? '',
+        balance: Number(store.state.balance ?? 0),
+        balanceStatus: String(store.state.balanceStatus ?? ''),
+        ready: Boolean(store.state.address) && store.state.balanceStatus === 'success'
+      }
+    }
+
+    const walletState = store.state[symbol.toLowerCase()] ?? {}
+
+    return {
+      address: String(walletState.address ?? ''),
+      balance: Number(walletState.balance ?? 0),
+      balanceStatus: String(walletState.balanceStatus ?? ''),
+      ready: Boolean(walletState.address) && walletState.balanceStatus === 'success',
+      feeRate: Number(walletState.feeRate ?? 0),
+      utxoCount: Array.isArray(walletState.utxo) ? walletState.utxo.length : 0
+    }
+  }, crypto)
+}
+
+const getSendFundsSnapshot = async (page: Page): Promise<SendFundsSnapshot> => {
+  return page.evaluate(() => {
+    const host = document.querySelector('.send-funds-form') as {
+      __vueParentComponent?: {
+        proxy?: Record<string, any>
+      }
+    } | null
+    const vm = host?.__vueParentComponent?.proxy
+
+    if (!vm) {
+      throw new Error('SendFundsForm vm is not available')
+    }
+
+    return {
+      allowIncreaseFee: Boolean(vm.allowIncreaseFee),
+      amountString: String(vm.amountString ?? ''),
+      balance: Number(vm.balance ?? 0),
+      cryptoAddress: String(vm.cryptoAddress ?? ''),
+      currency: String(vm.currency ?? ''),
+      dialog: Boolean(vm.dialog),
+      estimatedGasLimit: vm.estimatedGasLimit == null ? null : Number(vm.estimatedGasLimit),
+      exponent: Number(vm.exponent ?? 0),
+      increaseFee: Boolean(vm.increaseFee),
+      maxToTransfer: Number(vm.maxToTransfer ?? 0),
+      minToTransfer: Number(vm.minToTransfer ?? 0),
+      transferFee: Number(vm.transferFee ?? 0)
+    }
+  })
+}
+
+const formatAmount = (amount: number, decimals: number) => {
+  return amount.toFixed(decimals).replace(/\.?0+$/, '')
+}
+
+const floorAmount = (amount: number, decimals: number) => {
+  const factor = 10 ** decimals
+  return formatAmount(Math.floor(amount * factor) / factor, decimals)
+}
+
+const getAddressInput = (page: Page) =>
+  page.locator('.send-funds-form .a-input').nth(1).locator('input')
+const getAmountInput = (page: Page) => page.locator('.send-funds-form__amount-input input')
+const getConfirmDialog = (page: Page) => page.locator('.send-funds-confirm-dialog')
+const getSnackbar = (page: Page) => page.locator('.app-snackbar')
+
+const waitForWalletReady = async (page: Page, crypto: SpendableCrypto) => {
+  await expect
+    .poll(() => getRuntimeWalletState(page, crypto), {
+      timeout: LIVE_TIMEOUT
+    })
+    .toMatchObject({ ready: true })
+
+  const wallet = await getRuntimeWalletState(page, crypto)
+
+  if (crypto === 'BTC') {
+    expect(wallet.feeRate ?? 0).toBeGreaterThan(0)
+    expect(wallet.utxoCount ?? 0).toBeGreaterThan(0)
+  }
+
+  expect(wallet.address).not.toBe('')
+  expect(wallet.balance).toBeGreaterThan(0)
+
+  return wallet
+}
+
+const openTransferScreen = async (page: Page, crypto: SpendableCrypto) => {
+  await page.goto(`/transfer/${crypto}`, { waitUntil: 'domcontentloaded' })
+  await expect(page).toHaveURL(new RegExp(`/transfer/${crypto}$`))
+  await expect(page.locator('.send-funds-form')).toBeVisible()
+
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => snapshot.currency), {
+      timeout: LIVE_TIMEOUT
+    })
+    .toBe(crypto)
+
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => snapshot.balance), {
+      timeout: LIVE_TIMEOUT
+    })
+    .toBeGreaterThan(0)
+}
+
+const fillRecipient = async (page: Page, recipient: string) => {
+  const addressInput = getAddressInput(page)
+  await expect(addressInput).toBeVisible()
+  await addressInput.fill(recipient)
+
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => snapshot.cryptoAddress), {
+      timeout: 15_000
+    })
+    .toBe(recipient)
+}
+
+const pickSendAllAmount = async (page: Page) => {
+  await page.locator('.send-funds-form__menu-activator').nth(1).click()
+
+  const sendAllOption = page
+    .locator('.v-overlay .send-funds-form__menu-item-title')
+    .filter({ hasText: 'Send all' })
+    .last()
+
+  await expect(sendAllOption).toBeVisible()
+  await sendAllOption.click()
+
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => Number(snapshot.amountString || 0)), {
+      timeout: 15_000
+    })
+    .toBeGreaterThan(0)
+
+  const snapshot = await getSendFundsSnapshot(page)
+  const safeAmount = floorAmount(snapshot.maxToTransfer, snapshot.exponent)
+
+  if (
+    Number(snapshot.amountString || 0) > snapshot.maxToTransfer ||
+    Number(snapshot.amountString || 0) > Number(safeAmount)
+  ) {
+    await getAmountInput(page).fill(safeAmount)
+  }
+}
+
+const setIncreaseFee = async (page: Page, enabled: boolean) => {
+  const snapshot = await getSendFundsSnapshot(page)
+  expect(snapshot.allowIncreaseFee).toBe(true)
+
+  if (snapshot.increaseFee === enabled) {
+    return
+  }
+
+  const toggle = page.getByRole('checkbox', { name: 'Increase fee' })
+  await expect(toggle).toBeVisible()
+  await toggle.click()
+
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((nextSnapshot) => nextSnapshot.increaseFee), {
+      timeout: 15_000
+    })
+    .toBe(enabled)
+}
+
+const expectConfirmationAndCancel = async (
+  page: Page,
+  crypto: SpendableCrypto,
+  recipient: string
+) => {
+  const dialog = getConfirmDialog(page)
+
+  await page.locator('.send-funds-form__button').click()
+  await expect(dialog).toBeVisible()
+  await expect(dialog).toContainText('Transfer confirmation')
+  await expect(dialog).toContainText(crypto)
+  await expect(dialog).toContainText(recipient)
+
+  await dialog.getByRole('button', { name: 'Cancel' }).click()
+  await expect(dialog).toBeHidden()
+}
+
+const expectSnackbarMessage = async (page: Page, message: RegExp) => {
+  const snackbar = getSnackbar(page)
+  await expect(snackbar).toBeVisible()
+  await expect(snackbar).toContainText(message)
+}
+
+const closeSnackbar = async (page: Page) => {
+  const snackbar = getSnackbar(page)
+  if (!(await snackbar.isVisible().catch(() => false))) {
+    return
+  }
+
+  const closeButton = snackbar.locator('.app-snackbar__close-button')
+
+  if (await closeButton.isVisible().catch(() => false)) {
+    await closeButton.click()
+    await expect(snackbar).toBeHidden()
+    return
+  }
+
+  await expect(snackbar).toBeHidden({ timeout: 5_000 })
+}
+
+const runSupportedIncreaseFeeFlow = async (page: Page, crypto: 'BTC' | 'ETH' | 'USDT') => {
+  await openTransferScreen(page, crypto)
+  await fillRecipient(page, recipients[crypto])
+
+  await setIncreaseFee(page, false)
+  await pickSendAllAmount(page)
+  const offSnapshot = await getSendFundsSnapshot(page)
+  expect(offSnapshot.transferFee).toBeGreaterThan(0)
+  expect(Number(offSnapshot.amountString)).toBeGreaterThan(0)
+  await expectConfirmationAndCancel(page, crypto, recipients[crypto])
+
+  await setIncreaseFee(page, true)
+  await pickSendAllAmount(page)
+  const onSnapshot = await getSendFundsSnapshot(page)
+
+  expect(onSnapshot.transferFee).toBeGreaterThan(offSnapshot.transferFee)
+  if (crypto === 'USDT') {
+    expect(Number(onSnapshot.amountString)).toBe(Number(offSnapshot.amountString))
+  } else {
+    expect(Number(onSnapshot.amountString)).toBeLessThan(Number(offSnapshot.amountString))
+  }
+  await expectConfirmationAndCancel(page, crypto, recipients[crypto])
+}
+
+const runNoToggleFlow = async (page: Page, crypto: 'ADM' | 'DOGE' | 'DASH') => {
+  await openTransferScreen(page, crypto)
+  await fillRecipient(page, recipients[crypto])
+
+  const snapshot = await getSendFundsSnapshot(page)
+  expect(snapshot.allowIncreaseFee).toBe(false)
+  await expect(page.locator('.send-funds-form .v-selection-control')).toHaveCount(0)
+
+  await pickSendAllAmount(page)
+  const sendAllSnapshot = await getSendFundsSnapshot(page)
+
+  expect(sendAllSnapshot.transferFee).toBeGreaterThan(0)
+  expect(Number(sendAllSnapshot.amountString)).toBeGreaterThan(0)
+  await expectConfirmationAndCancel(page, crypto, recipients[crypto])
+}
+
+const expectValidationError = async (page: Page, amount: string, message: RegExp) => {
+  const amountInput = getAmountInput(page)
+  const dialog = getConfirmDialog(page)
+
+  await amountInput.fill(amount)
+  await page.locator('.send-funds-form__button').click()
+
+  await expect(dialog).toBeHidden()
+  await expectSnackbarMessage(page, message)
+  await closeSnackbar(page)
+
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => snapshot.dialog), {
+      timeout: 5_000
+    })
+    .toBe(false)
+}
+
+test.describe('Send funds live-account no-broadcast regressions', () => {
+  test.beforeEach(async ({ page }) => {
+    test.skip(!testPassphrase, 'Requires ADM_TEST_ACCOUNT_PK in .env.local')
+
+    await page.setViewportSize({ width: 1366, height: 900 })
+    await loginWithPassphrase(page, testPassphrase!)
+  })
+
+  test('reaches confirmation for 100% ADM send and keeps Increase fee unavailable', async ({
+    page
+  }) => {
+    test.slow()
+    await waitForWalletReady(page, 'ADM')
+    await runNoToggleFlow(page, 'ADM')
+  })
+
+  test('reaches confirmation for 100% BTC send with Increase fee off and on', async ({ page }) => {
+    test.slow()
+    await waitForWalletReady(page, 'BTC')
+    await runSupportedIncreaseFeeFlow(page, 'BTC')
+  })
+
+  test('reaches confirmation for 100% ETH send with Increase fee off and on', async ({ page }) => {
+    test.slow()
+    await waitForWalletReady(page, 'ETH')
+    await runSupportedIncreaseFeeFlow(page, 'ETH')
+  })
+
+  test('reaches confirmation for 100% USDT send with Increase fee off and on', async ({ page }) => {
+    test.slow()
+    await waitForWalletReady(page, 'USDT')
+    await runSupportedIncreaseFeeFlow(page, 'USDT')
+  })
+
+  test('reaches confirmation for 100% DOGE send and keeps Increase fee unavailable', async ({
+    page
+  }) => {
+    test.slow()
+    await waitForWalletReady(page, 'DOGE')
+    await runNoToggleFlow(page, 'DOGE')
+  })
+
+  test('reaches confirmation for 100% DASH send and keeps Increase fee unavailable', async ({
+    page
+  }) => {
+    test.slow()
+    await waitForWalletReady(page, 'DASH')
+    await runNoToggleFlow(page, 'DASH')
+  })
+
+  test('shows validation errors for below-min and above-balance amounts without opening confirmation', async ({
+    page
+  }) => {
+    test.slow()
+
+    for (const crypto of spendableCryptos) {
+      await waitForWalletReady(page, crypto)
+      await openTransferScreen(page, crypto)
+      await fillRecipient(page, recipients[crypto])
+
+      await expectValidationError(page, dustAmounts[crypto], /Dust amount/i)
+
+      const snapshot = await getSendFundsSnapshot(page)
+      const tooMuchAmount = formatAmount(snapshot.maxToTransfer + 1, snapshot.exponent)
+
+      await expectValidationError(page, tooMuchAmount, /Not enough tokens/i)
+    }
+  })
+})

--- a/tests/e2e/send-funds-live-account.spec.ts
+++ b/tests/e2e/send-funds-live-account.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test, type Page } from '@playwright/test'
-import { loginWithPassphrase } from './helpers/auth'
+import { dismissAddressWarningIfVisible, loginWithPassphrase } from './helpers/auth'
 import { testPassphrase } from './helpers/env'
 
-const LIVE_TIMEOUT = 120_000
+const LIVE_TIMEOUT = 180_000
 
 const recipients = {
   ADM: 'U12345678901234567890',
@@ -135,10 +135,25 @@ const getSnackbar = (page: Page) => page.locator('.app-snackbar')
 
 const waitForWalletReady = async (page: Page, crypto: SpendableCrypto) => {
   await expect
-    .poll(() => getRuntimeWalletState(page, crypto), {
-      timeout: LIVE_TIMEOUT
-    })
-    .toMatchObject({ ready: true })
+    .poll(
+      async () => {
+        const wallet = await getRuntimeWalletState(page, crypto)
+
+        if (!wallet.ready || !wallet.address || wallet.balance <= 0) {
+          return false
+        }
+
+        if (crypto === 'BTC') {
+          return (wallet.feeRate ?? 0) > 0 && (wallet.utxoCount ?? 0) > 0
+        }
+
+        return true
+      },
+      {
+        timeout: LIVE_TIMEOUT
+      }
+    )
+    .toBe(true)
 
   const wallet = await getRuntimeWalletState(page, crypto)
 
@@ -156,6 +171,7 @@ const waitForWalletReady = async (page: Page, crypto: SpendableCrypto) => {
 const openTransferScreen = async (page: Page, crypto: SpendableCrypto) => {
   await page.goto(`/transfer/${crypto}`, { waitUntil: 'domcontentloaded' })
   await expect(page).toHaveURL(new RegExp(`/transfer/${crypto}$`))
+  await dismissAddressWarningIfVisible(page, 8_000)
   await expect(page.locator('.send-funds-form')).toBeVisible()
 
   await expect
@@ -184,6 +200,12 @@ const fillRecipient = async (page: Page, recipient: string) => {
 }
 
 const pickSendAllAmount = async (page: Page) => {
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => snapshot.maxToTransfer), {
+      timeout: 30_000
+    })
+    .toBeGreaterThan(0)
+
   await page.locator('.send-funds-form__menu-activator').nth(1).click()
 
   const sendAllOption = page
@@ -194,13 +216,19 @@ const pickSendAllAmount = async (page: Page) => {
   await expect(sendAllOption).toBeVisible()
   await sendAllOption.click()
 
+  let snapshot = await getSendFundsSnapshot(page)
+  if (Number(snapshot.amountString || 0) <= 0 && snapshot.maxToTransfer > 0) {
+    const safeAmount = floorAmount(snapshot.maxToTransfer, snapshot.exponent)
+    await getAmountInput(page).fill(safeAmount)
+    snapshot = await getSendFundsSnapshot(page)
+  }
+
   await expect
     .poll(() => getSendFundsSnapshot(page).then((snapshot) => Number(snapshot.amountString || 0)), {
-      timeout: 15_000
+      timeout: 30_000
     })
     .toBeGreaterThan(0)
 
-  const snapshot = await getSendFundsSnapshot(page)
   const safeAmount = floorAmount(snapshot.maxToTransfer, snapshot.exponent)
 
   if (
@@ -247,6 +275,36 @@ const expectConfirmationAndCancel = async (
   await expect(dialog).toBeHidden()
 }
 
+const waitForTransferFee = async (page: Page) => {
+  await expect
+    .poll(() => getSendFundsSnapshot(page).then((snapshot) => snapshot.transferFee), {
+      timeout: 30_000
+    })
+    .toBeGreaterThan(0)
+}
+
+const clampAmountToCurrentMax = async (page: Page) => {
+  const snapshot = await getSendFundsSnapshot(page)
+  const currentAmount = Number(snapshot.amountString || 0)
+
+  if (currentAmount <= 0 || currentAmount <= snapshot.maxToTransfer) {
+    return
+  }
+
+  const safeAmount = floorAmount(snapshot.maxToTransfer, snapshot.exponent)
+  await getAmountInput(page).fill(safeAmount)
+
+  await expect
+    .poll(
+      () =>
+        getSendFundsSnapshot(page).then((nextSnapshot) => Number(nextSnapshot.amountString || 0)),
+      {
+        timeout: 15_000
+      }
+    )
+    .toBeLessThanOrEqual(snapshot.maxToTransfer)
+}
+
 const expectSnackbarMessage = async (page: Page, message: RegExp) => {
   const snackbar = getSnackbar(page)
   await expect(snackbar).toBeVisible()
@@ -276,6 +334,8 @@ const runSupportedIncreaseFeeFlow = async (page: Page, crypto: 'BTC' | 'ETH' | '
 
   await setIncreaseFee(page, false)
   await pickSendAllAmount(page)
+  await waitForTransferFee(page)
+  await clampAmountToCurrentMax(page)
   const offSnapshot = await getSendFundsSnapshot(page)
   expect(offSnapshot.transferFee).toBeGreaterThan(0)
   expect(Number(offSnapshot.amountString)).toBeGreaterThan(0)
@@ -283,6 +343,8 @@ const runSupportedIncreaseFeeFlow = async (page: Page, crypto: 'BTC' | 'ETH' | '
 
   await setIncreaseFee(page, true)
   await pickSendAllAmount(page)
+  await waitForTransferFee(page)
+  await clampAmountToCurrentMax(page)
   const onSnapshot = await getSendFundsSnapshot(page)
 
   expect(onSnapshot.transferFee).toBeGreaterThan(offSnapshot.transferFee)
@@ -303,6 +365,8 @@ const runNoToggleFlow = async (page: Page, crypto: 'ADM' | 'DOGE' | 'DASH') => {
   await expect(page.locator('.send-funds-form .v-selection-control')).toHaveCount(0)
 
   await pickSendAllAmount(page)
+  await waitForTransferFee(page)
+  await clampAmountToCurrentMax(page)
   const sendAllSnapshot = await getSendFundsSnapshot(page)
 
   expect(sendAllSnapshot.transferFee).toBeGreaterThan(0)


### PR DESCRIPTION
## Description

This PR stabilizes Send funds flows and crypto transfer status handling across the PWA.

It includes:

- bigint-safe BTC-family output creation for `bitcoinjs-lib@7`
- fixed-fee alignment for DOGE transaction building
- Send funds `Escape` behavior fixes
- live/offline/env-backed coverage for ADM, BTC, ETH, USDT, DOGE, and DASH send pipelines
- status synchronization fixes between chat bubble, chat preview, transaction list, and transaction details
- safer `txFetchInfo` usage for pending/rejected transitions
- consistency-check fixes for native ADM transfers and KVS-backed sender/recipient validation
- session-cache and remount fixes for stale `INVALID` / `REJECTED` / `CONFIRMED` states
- partner resolution fixes for `Continue chat`
- regression coverage for pending, rejected, invalid, and inconsistency-reason scenarios

## Related issue

Closes #947

## How to test

- Run `npm run lint`
- Run `npm run typecheck`
- Run `npm run test -- --run`
- In a test account, verify `Send funds` for ADM, BTC, ETH, USDT, DOGE, and DASH reaches the confirmation dialog without broadcasting in the added coverage paths
- In chats and `/chats`, verify crypto transfer statuses stay synchronized with transaction details after opening, remounting, and returning back
- Verify DOGE/DASH historical transfers do not flash false `Inconsistent` or `Confirmed` statuses while KVS-based validation is still resolving
- Verify manual status refresh from chat/details resets to `Pending` and then resolves back to the live final status

## Risk areas

- transaction building for BTC-family chains and fixed-fee coins
- session-scoped status caching and remount behavior
- KVS-backed consistency checks for historical crypto transfers
- live env-backed tests that depend on current node availability and the configured test account

## Checklist

- [x] Issue linked
- [x] Tests updated for affected behavior
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test -- --run`
